### PR TITLE
JC-1926 Added space between words and a checkbox/radio

### DIFF
--- a/jcommune-view/jcommune-web-view/src/main/webapp/resources/css/lib/inline.css
+++ b/jcommune-view/jcommune-web-view/src/main/webapp/resources/css/lib/inline.css
@@ -24,10 +24,11 @@
     display: inline-block;
 }
 
-input.form-check-radio-box[type="checkbox"],
-input.form-check-radio-box[type="radio"] {
+/* JC-1926 - Space between the word and the checkbox in topic with vote. */
+.control-group input[type=checkbox],
+.control-group input[type=radio] {
     float: left;
-    margin-right: 10px;
+    margin-right: 5px;
 }
 
 .form-login-related {


### PR DESCRIPTION
- inline.css was modified because of inconsistency in selectors: "input"
  tag does not have "form-check-radio-box" class
