### PR TITLE
JC-1878 Add ability to create an admin user on first deployment

### DIFF
--- a/jcommune-model/src/main/resources/org/jtalks/jcommune/migrations/V64__Add_admin_user.sql
+++ b/jcommune-model/src/main/resources/org/jtalks/jcommune/migrations/V64__Add_admin_user.sql
@@ -1,0 +1,59 @@
+SET @adminUserName := 'admin';
+SET @adminGroupName := 'Administrators';
+SET @forumComponentName := 'JTalks Sample Forum';
+SET @forumComponentType := 'FORUM';
+SET @aclClass :='COMPONENT';
+
+insert ignore into COMPONENTS (CMP_ID, COMPONENT_TYPE, UUID, `NAME`, DESCRIPTION) VALUES (2, @forumComponentType, (SELECT UUID() FROM dual), @forumComponentName, 'Available users: admin/admin');
+
+-- 'FROM COMPONENTS' are not used, but query mast contain 'FROM dual' clause
+--  @see <a href="http://dev.mysql.com">http://dev.mysql.com/doc/refman/5.0/en/select.html/a>.
+insert ignore into GROUPS (UUID, `NAME`, DESCRIPTION) VALUES ((SELECT UUID() FROM dual), 'Moderators', 'General group for all moderators');
+
+-- IGNORE can be used here because USERNAME is unique column, so if table contain user with username='Admin', record
+--  will not be added.
+insert ignore into USERS (UUID, USERNAME, ENCODED_USERNAME, EMAIL, PASSWORD, ROLE, SALT, ENABLED) VALUES
+  ((SELECT UUID() FROM dual), 'admin', 'admin', 'admin@jtalks.org', MD5('admin'), 'USER_ROLE', '',true);
+insert ignore into JC_USER_DETAILS (USER_ID, REGISTRATION_DATE, POST_COUNT) values
+  ((select ID from USERS where USERNAME = 'admin'), NOW(), 0);
+
+-- Adding created Admin to Administrators group(created at this migration or common migration) ).
+SET @admin_group_id := (select GROUP_ID from GROUPS where `NAME`='Administrators');
+insert into GROUP_USER_REF (GROUP_ID, USER_ID) select @admin_group_id, ID from USERS where USERNAME = 'admin' and not exists (select * from GROUP_USER_REF where GROUP_ID = @admin_group_id and USER_ID = USERS.ID);
+
+-- Adding record with added component class.
+set @component_acl_class=1;
+set @group_acl_class=2;
+set @branch_acl_class=3;
+insert ignore into acl_class values (@branch_acl_class,'BRANCH'), (@group_acl_class,'GROUP'), (@component_acl_class,'COMPONENT');
+
+SET @acl_sid_group := (SELECT GROUP_CONCAT('usergroup:', CONVERT(GROUP_ID, char(19))) FROM GROUPS g WHERE g.NAME = @adminGroupName);
+SET @acl_sid_user := (SELECT GROUP_CONCAT('user:', CONVERT(ID, char(19))) FROM USERS u WHERE u.USERNAME = @adminUserName);
+SET @object_id_identity := (SELECT component.CMP_ID FROM COMPONENTS component WHERE component.COMPONENT_TYPE = @forumComponentType);
+
+-- Adding record to acl_sid table, this record wires sid and user id.
+INSERT IGNORE INTO acl_sid (principal, sid)
+VALUES(1, @acl_sid_user);
+
+SET @acl_sid_id_user := (SELECT sid.id FROM acl_sid sid WHERE sid.sid = @acl_sid_user);
+
+-- Adding record to acl_sid table, this record wires sid and group id.
+INSERT IGNORE INTO acl_sid (principal, sid)
+VALUES(0, @acl_sid_group);
+
+SET @acl_sid_id_group := (SELECT sid.id FROM acl_sid sid WHERE sid.sid = @acl_sid_group);
+
+SET @acl_class_id :=(SELECT class.id FROM acl_class class WHERE class.class = @aclClass);
+
+INSERT IGNORE INTO acl_object_identity (object_id_class, object_id_identity, owner_sid, entries_inheriting)
+  SELECT @acl_class_id, @object_id_identity, @acl_sid_id_user, 1 FROM dual;
+
+SET @acl_object_identity_id := (SELECT aoi.id FROM acl_object_identity aoi
+WHERE aoi.object_id_class = @acl_class_id
+      AND aoi.object_id_identity = @object_id_identity);
+
+SET @ace_order_max := (SELECT MAX(ae.ace_order) FROM acl_entry ae);
+SET @ace_order := (CASE WHEN  @ace_order_max is null THEN 0 ELSE @ace_order_max+1 END);
+
+INSERT IGNORE INTO acl_entry (acl_object_identity, sid, ace_order, mask, granting, audit_success, audit_failure)
+  SELECT @acl_object_identity_id, @acl_sid_id_group, @ace_order, 16, 1, 0 , 0 FROM dual;

--- a/jcommune-model/src/main/resources/org/jtalks/jcommune/model/sample-forum.sql
+++ b/jcommune-model/src/main/resources/org/jtalks/jcommune/model/sample-forum.sql
@@ -1,7 +1,13 @@
--- Creates users: default, admin, banned with respective permissions
+-- Creates users: registered, moderator, banned with respective permissions
 -- Creates sections and branches to be able to see then and post something
 set @forum_component_id := 2;
-insert ignore into COMPONENTS (CMP_ID, COMPONENT_TYPE, UUID, `NAME`, DESCRIPTION) VALUES (2, 'FORUM', (SELECT UUID() FROM dual), 'JTalks Sample Forum', 'Available users: admin/admin registered/registered moderator/moderator banned/banned');
+update COMPONENTS set DESCRIPTION='Available users: admin/admin registered/registered moderator/moderator banned/banned' where CMP_ID=2;
+
+-- Delete old permissions for admin user
+delete from acl_entry where id=1;
+delete from acl_object_identity  where id=1;
+ALTER TABLE acl_entry AUTO_INCREMENT=1;
+ALTER TABLE acl_object_identity AUTO_INCREMENT=1;
 
 insert ignore into SECTIONS (SECTION_ID, UUID, `NAME`, DESCRIPTION, POSITION, COMPONENT_ID) VALUES
   (1,(SELECT UUID() FROM dual),'Sport', 'All about sport', 1, @forum_component_id),
@@ -14,9 +20,9 @@ insert ignore into SECTIONS (SECTION_ID, UUID, `NAME`, DESCRIPTION, POSITION, CO
   (8,(SELECT UUID() FROM dual),'Hi-tech', 'Technologies', 8, @forum_component_id),
   (9,(SELECT UUID() FROM dual),'People', 'All about mankind', 9, @forum_component_id),
   (10,(SELECT UUID() FROM dual),'Leisure', 'Have free time?', 9, @forum_component_id);
-  
+
 -- GROUPS BEGIN
-insert ignore into GROUPS (UUID, `NAME`, DESCRIPTION) VALUES ((SELECT UUID() FROM dual), 'Moderators', 'General group for all moderators');
+
 SET @admin_group_id := (select GROUP_ID from GROUPS where `NAME`='Administrators');
 SET @registered_group_id := (select GROUP_ID from GROUPS where `NAME`='Registered Users');
 SET @banned_group_id := (select GROUP_ID from GROUPS where `NAME`='Banned Users');
@@ -34,7 +40,7 @@ insert ignore into BRANCHES (BRANCH_ID, UUID, `NAME`, DESCRIPTION, POSITION, SEC
   (3, UUID(), 'Field hockey', 'Sticks and balls on the grass', 2, 1 ,1),
   (4, UUID(), 'Korfball', 'It is NOT basketball!!', 3, 1 ,1),
   (5, UUID(), 'Sepak takraw', 'Rattan balls,', 4, 1 ,1),
-  
+
   (6, UUID(), 'Bicycle', 'Two wheels', 0, 2, 1),
   (7, UUID(), 'Rickshaw', '', 1, 2 ,1),
   (8, UUID(), 'Horse', 'Still actual', 2, 2 ,1),
@@ -46,43 +52,43 @@ insert ignore into BRANCHES (BRANCH_ID, UUID, `NAME`, DESCRIPTION, POSITION, SEC
   (13, UUID(), 'America', 'Other hemisphere', 2, 3 ,1),
   (14, UUID(), 'Africa', 'Too hot?', 3, 3 ,1),
   (15, UUID(), 'Australia', 'Something very interesting', 4, 3 ,1),
-  
+
   (16, UUID(), 'Classic', 'Checked by ages', 0, 4, 1),
   (17, UUID(), 'Rock', 'Something heavier?', 1, 4, 1),
   (18, UUID(), 'Electronic', '', 2, 4 ,1),
   (19, UUID(), 'Pop', 'La-la', 3, 4 ,1),
   (20, UUID(), 'Rap', 'Yo!', 4, 4 ,1),
-  
+
   (21, UUID(), 'Ancient', 'Rome, Greece', 0, 5, 1),
   (22, UUID(), 'Middle Ages', 'Europe', 1, 5 ,1),
   (23, UUID(), 'Renaissance', 'Still Europe', 2, 5 ,1),
   (24, UUID(), 'Modern', 'All Earth', 3, 5 ,1),
   (25, UUID(), 'Future', 'Go ahead all over the world', 4, 5 ,1),
-  
+
   (26, UUID(), 'Sci-fi', 'What about something unbelievable?', 0, 6, 1),
   (27, UUID(), 'Adventures', 'Breathtaking books', 1, 6 ,1),
   (28, UUID(), 'Fairytales', 'Not only for kids', 2, 6 ,1),
   (29, UUID(), 'Realism', 'All about our life', 3, 6 ,1),
   (30, UUID(), 'Comedy', 'LOL', 4, 6 ,1),
-  
+
   (31, UUID(), 'TV shows', 'Funny and useful', 0, 7, 1),
   (32, UUID(), 'News', 'From north to south', 1, 7 ,1),
   (33, UUID(), 'Cartoon', 'Kids time', 2, 7 ,1),
   (34, UUID(), 'Discovery', 'All Earth', 3, 7 ,1),
   (35, UUID(), 'Advertisement', 'Part of the TV', 4, 7 ,1),
-  
+
   (36, UUID(), 'Hard', 'Components', 0, 8, 1),
   (37, UUID(), 'Soft', 'Applications', 1, 8 ,1),
   (38, UUID(), 'Programming', 'Development', 2, 8 ,1),
   (39, UUID(), 'Network', 'World wide web', 3, 8 ,1),
   (40, UUID(), 'Electronics', 'Devices', 4, 8 ,1),
-  
+
   (41, UUID(), 'Philosophy', 'Wisdom', 0, 9, 1),
   (42, UUID(), 'Sociology', 'Human behaviour', 1, 9 ,1),
   (43, UUID(), 'Psychology', 'Human motives', 2, 9 ,1),
   (44, UUID(), 'Education', 'Evolution', 3, 9 ,1),
   (45, UUID(), 'Religion', 'Human faith', 4, 9 ,1),
-  
+
   (46, UUID(), 'Theatre', 'Performances', 0, 10, 1),
   (47, UUID(), 'Cinema', 'New blockbusters', 1, 10 ,1),
   (48, UUID(), 'Exhibitions', 'Art', 2, 10 ,1),
@@ -91,12 +97,10 @@ insert ignore into BRANCHES (BRANCH_ID, UUID, `NAME`, DESCRIPTION, POSITION, SEC
 -- ****USERS CREATION BEGIN****
 -- Creates a default users with admin/admin, registered/registered, moderator/moderator, banned/banned credentials to be able to log in without manual registration
 insert ignore into USERS (UUID, USERNAME, ENCODED_USERNAME, EMAIL, PASSWORD, ROLE, SALT, ENABLED) VALUES
-  ((SELECT UUID() FROM dual), 'admin', 'admin', 'admin@jtalks.org', MD5('admin'), 'USER_ROLE', '',true),
   ((SELECT UUID() FROM dual), 'registered', 'registered', 'registered@jtalks.org', MD5('registered'), 'USER_ROLE', '',true),
   ((SELECT UUID() FROM dual), 'moderator', 'moderator', 'moderator@jtalks.org', MD5('moderator'), 'USER_ROLE', '', true),
   ((SELECT UUID() FROM dual), 'banned', 'banned', 'banned@jtalks.org', MD5('banned'), 'USER_ROLE', '', true);
 insert ignore into JC_USER_DETAILS (USER_ID, REGISTRATION_DATE, POST_COUNT) values
-  ((select ID from USERS where USERNAME = 'admin'), NOW(), 0),
   ((select ID from USERS where USERNAME = 'registered'), NOW(), 0),
   ((select ID from USERS where USERNAME = 'moderator'), NOW(), 0),
   ((select ID from USERS where USERNAME = 'banned'), NOW(), 0) ;
@@ -104,14 +108,12 @@ insert ignore into JC_USER_DETAILS (USER_ID, REGISTRATION_DATE, POST_COUNT) valu
 
 -- Add users to appropriate groups
 insert ignore into GROUP_USER_REF select @registered_group_id, ID from USERS;
-insert ignore into GROUP_USER_REF select @moderator_group_id, ID from USERS where USERNAME in ('moderator', 'admin');
-insert ignore into GROUP_USER_REF select @admin_group_id, ID from USERS where USERNAME = 'admin';
+insert ignore into GROUP_USER_REF select @moderator_group_id, ID from USERS where USERNAME = 'moderator';
 insert ignore into GROUP_USER_REF select @banned_group_id, ID from USERS where USERNAME = 'banned';
 
 set @component_acl_class=1;
 set @group_acl_class=2;
 set @branch_acl_class=3;
-insert ignore into acl_class values (@branch_acl_class,'BRANCH'), (@group_acl_class,'GROUP'), (@component_acl_class,'COMPONENT');
 
 insert into acl_sid(principal, sid) values (0, @moderator_group_sid);
 


### PR DESCRIPTION
New migration file 'V64__Add_admin_user.sql' was added.

sample-forum.sql file was changed to deploy only registered,
banned and moderator users, because admin is created with first deploy.
