### PR TITLE
JC-2122 Fix empty field after validation error in profile

### DIFF
--- a/jcommune-view/jcommune-web-view/src/main/webapp/WEB-INF/jsp/editUserProfile.jsp
+++ b/jcommune-view/jcommune-web-view/src/main/webapp/WEB-INF/jsp/editUserProfile.jsp
@@ -21,6 +21,9 @@
 <%@ taglib prefix="jtalks" uri="http://www.jtalks.org/tags" %>
 
 <form:hidden path="userProfileDto.userId"/>
+<form:hidden path="userProfileDto.registrationDate"/>
+<form:hidden path="userProfileDto.lastLogin"/>
+<form:hidden path="userProfileDto.postCount"/>
 
 <div class="user-profile-top-buttons">
   <c:if test="${param.isCanEditProfile}">


### PR DESCRIPTION
I added data for fields "Registration date", "Last login" and "Post Count".
Now the data is sent over hidden form fields if there is a validation error.