### PR TITLE
JC-2016 New draft validation policy

### DIFF
--- a/jcommune-view/jcommune-web-controller/src/main/java/org/jtalks/jcommune/web/controller/PrivateMessageController.java
+++ b/jcommune-view/jcommune-web-controller/src/main/java/org/jtalks/jcommune/web/controller/PrivateMessageController.java
@@ -21,12 +21,16 @@ import org.jtalks.jcommune.service.PrivateMessageService;
 import org.jtalks.jcommune.service.UserService;
 import org.jtalks.jcommune.plugin.api.exceptions.NotFoundException;
 import org.jtalks.jcommune.service.nontransactional.BBCodeService;
+import org.jtalks.jcommune.web.dto.PrivateMessageDraftDto;
 import org.jtalks.jcommune.web.dto.PrivateMessageDto;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.propertyeditors.StringTrimmerEditor;
 import org.springframework.data.domain.Page;
 import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.validation.BeanPropertyBindingResult;
 import org.springframework.validation.BindingResult;
+import org.springframework.validation.ObjectError;
 import org.springframework.web.bind.WebDataBinder;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.servlet.ModelAndView;
@@ -241,9 +245,11 @@ public class PrivateMessageController {
      * @return redirect to "drafts" folder if saved successfully or show form with error message
      */
     @RequestMapping(value = "/pm/save", method = {RequestMethod.POST, RequestMethod.GET})
-    public String saveDraft(@Valid @ModelAttribute PrivateMessageDto pmDto, BindingResult result) {
+    public String saveDraft(@Valid @ModelAttribute PrivateMessageDraftDto pmDto, BindingResult result, Model model) {
         String targetView = "redirect:/drafts";
         if (result.hasErrors()) {
+            rebindErrors(pmDto, result, model);
+            model.addAttribute(DTO, pmDto);
             return PM_FORM;
         }
 
@@ -256,6 +262,22 @@ public class PrivateMessageController {
         }
 
         return targetView;
+    }
+
+    /**
+     * Rebind errors from object with name "privateMessageDraftDto" to object with name {@link #DTO}
+     * Needed for possibility to use same view for creation of drafts and sending private messages
+     *
+     * @param pmDto Dto populated in form
+     * @param result validation result
+     * @param model model to be transferred to view
+     */
+    private void rebindErrors(PrivateMessageDraftDto pmDto, BindingResult result, Model model) {
+        BindingResult newResult = new BeanPropertyBindingResult(pmDto, DTO);
+        for (ObjectError error : result.getAllErrors()) {
+            newResult.addError(error);
+        }
+        model.addAllAttributes(newResult.getModel());
     }
 
     /**

--- a/jcommune-view/jcommune-web-controller/src/main/java/org/jtalks/jcommune/web/dto/PrivateMessageDraftDto.java
+++ b/jcommune-view/jcommune-web-controller/src/main/java/org/jtalks/jcommune/web/dto/PrivateMessageDraftDto.java
@@ -1,0 +1,76 @@
+/**
+ * Copyright (C) 2011  JTalks.org Team
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+package org.jtalks.jcommune.web.dto;
+
+import org.jtalks.jcommune.model.entity.JCUser;
+import org.jtalks.jcommune.model.entity.PrivateMessage;
+import org.jtalks.jcommune.web.validation.annotations.AtLeastOneNotEmpty;
+import org.jtalks.jcommune.web.validation.annotations.Exists;
+
+import javax.validation.constraints.Size;
+
+/**
+ * This class has same fields as {@link org.jtalks.jcommune.web.dto.PrivateMessageDto} but different validation
+ * rules. Needed to implement different validation rules while saving drafts
+ *
+ * @author Mikhail Stryzhonok
+ */
+@AtLeastOneNotEmpty(fieldNames = {"body", "title", "recipient"})
+public class PrivateMessageDraftDto {
+
+    @Size(max = PrivateMessage.MAX_TITLE_LENGTH)
+    private String title;
+
+    @Size(max = PrivateMessage.MAX_MESSAGE_LENGTH)
+    private String body;
+
+    @Exists(entity = JCUser.class, field = "username", message = "{validation.wrong_recipient}", ignoreCase=true,
+            isNullableAllowed = true)
+    private String recipient;
+
+    private long id;
+
+    public String getTitle() {
+        return title;
+    }
+
+    public void setTitle(String title) {
+        this.title = title;
+    }
+
+    public String getBody() {
+        return body;
+    }
+
+    public void setBody(String body) {
+        this.body = body;
+    }
+
+    public String getRecipient() {
+        return recipient;
+    }
+
+    public void setRecipient(String recipient) {
+        this.recipient = recipient;
+    }
+
+    public long getId() {
+        return id;
+    }
+
+    public void setId(long id) {
+        this.id = id;
+    }
+}

--- a/jcommune-view/jcommune-web-controller/src/main/java/org/jtalks/jcommune/web/validation/annotations/AtLeastOneNotEmpty.java
+++ b/jcommune-view/jcommune-web-controller/src/main/java/org/jtalks/jcommune/web/validation/annotations/AtLeastOneNotEmpty.java
@@ -14,8 +14,7 @@
  */
 package org.jtalks.jcommune.web.validation.annotations;
 
-import org.jtalks.common.model.entity.Entity;
-import org.jtalks.jcommune.web.validation.validators.ExistenceValidator;
+import org.jtalks.jcommune.web.validation.validators.AtLeastOneNotEmptyValidator;
 
 import javax.validation.Constraint;
 import javax.validation.Payload;
@@ -26,51 +25,35 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * Marks the field to check it's value for existence in a database.
- * You should specify an Entity and a field to search for value in.
+ * Validates that at lest of specified string fields in class is not empty
  *
- * <p>Works only for sting variables as for now.
- *
- * @author Evgeniy Naumenko
+ * @author Mikhail Stryzhonok
  */
-@Target({ElementType.FIELD})
+@Target({ElementType.ANNOTATION_TYPE, ElementType.TYPE})
 @Retention(RetentionPolicy.RUNTIME)
+@Constraint(validatedBy = AtLeastOneNotEmptyValidator.class)
 @Documented
-@Constraint(validatedBy = ExistenceValidator.class)
-public @interface Exists {
+public @interface AtLeastOneNotEmpty {
 
     /**
-     * If set to <b>true</b> checking field can be null
+     * Array with names of fields to check
      */
-    boolean isNullableAllowed() default false;
+    String[] fieldNames();
 
     /**
-     * Resource bundle code for error message
+     * Message for display when validation fails.
      */
-    String message();
+    String message() default "";
 
     /**
-     * Groups settings for this validation constraint
+     * Groups element that specifies the processing groups with which the
+     * constraint declaration is associated.
      */
     Class<?>[] groups() default {};
 
     /**
-     * Payload, not used here
+     * Payload element that specifies the payload with which the the
+     * constraint declaration is associated.
      */
     Class<? extends Payload>[] payload() default {};
-
-    /**
-     * Entity to be verified
-     */
-    Class<? extends Entity> entity();
-
-    /**
-     * Field to be checked
-     */
-    String field();
-    
-    /**
-     * Ignore case or not when checking for existence
-     */
-    boolean ignoreCase() default false;
 }

--- a/jcommune-view/jcommune-web-controller/src/main/java/org/jtalks/jcommune/web/validation/validators/AtLeastOneNotEmptyValidator.java
+++ b/jcommune-view/jcommune-web-controller/src/main/java/org/jtalks/jcommune/web/validation/validators/AtLeastOneNotEmptyValidator.java
@@ -1,0 +1,48 @@
+/**
+ * Copyright (C) 2011  JTalks.org Team
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+package org.jtalks.jcommune.web.validation.validators;
+
+import net.sf.ehcache.hibernate.management.impl.BeanUtils;
+import org.jtalks.jcommune.web.validation.annotations.AtLeastOneNotEmpty;
+
+import javax.validation.ConstraintValidator;
+import javax.validation.ConstraintValidatorContext;
+
+/**
+ * @author Mikhail Stryzhonok
+ */
+public class AtLeastOneNotEmptyValidator implements ConstraintValidator<AtLeastOneNotEmpty, Object> {
+
+    private String[] fieldNames;
+
+    @Override
+    public void initialize(AtLeastOneNotEmpty constraintAnnotation) {
+        fieldNames = constraintAnnotation.fieldNames();
+    }
+
+    @Override
+    public boolean isValid(Object value, ConstraintValidatorContext context) {
+        if (value == null) {
+            return true;
+        }
+        for (String name : fieldNames) {
+            Object property = BeanUtils.getBeanProperty(value, name);
+            if (property instanceof String && ((String) property).trim().length() > 0) {
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/jcommune-view/jcommune-web-controller/src/main/java/org/jtalks/jcommune/web/validation/validators/ExistenceValidator.java
+++ b/jcommune-view/jcommune-web-controller/src/main/java/org/jtalks/jcommune/web/validation/validators/ExistenceValidator.java
@@ -33,6 +33,7 @@ public class ExistenceValidator implements ConstraintValidator<Exists, String> {
     private Class<? extends Entity> entity;
     private String field;
     private boolean ignoreCase;
+    private boolean nullableAllowed;
 
     private ValidatorDao<String> dao;
 
@@ -52,6 +53,7 @@ public class ExistenceValidator implements ConstraintValidator<Exists, String> {
         this.entity = annotation.entity();
         this.field = annotation.field();
         this.ignoreCase = annotation.ignoreCase();
+        this.nullableAllowed = annotation.isNullableAllowed();
     }
 
     /**
@@ -59,6 +61,10 @@ public class ExistenceValidator implements ConstraintValidator<Exists, String> {
      */
     @Override
     public boolean isValid(String value, ConstraintValidatorContext context) {
-        return (value != null) && dao.isExists(entity, field, value, ignoreCase);
+        if (nullableAllowed) {
+            return (value == null) || dao.isExists(entity, field, value, ignoreCase);
+        } else {
+            return (value != null) && dao.isExists(entity, field, value, ignoreCase);
+        }
     }
 }

--- a/jcommune-view/jcommune-web-controller/src/main/java/org/jtalks/jcommune/web/validation/validators/ValidatorStub.java
+++ b/jcommune-view/jcommune-web-controller/src/main/java/org/jtalks/jcommune/web/validation/validators/ValidatorStub.java
@@ -1,0 +1,47 @@
+/**
+ * Copyright (C) 2011  JTalks.org Team
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+package org.jtalks.jcommune.web.validation.validators;
+
+import org.springframework.validation.Errors;
+import org.springframework.validation.Validator;
+
+/**
+ * Simple implementation of {@link org.springframework.validation.Validator} interface.
+ * Should be used in tests with Spring MockMVC framework
+ *
+ * @author Mikhail Stryzhonok
+ */
+public class ValidatorStub implements Validator {
+
+    private String[] errorFields;
+
+    public ValidatorStub(String ... errorFields) {
+        this.errorFields = errorFields;
+    }
+
+    @Override
+    public boolean supports(Class<?> clazz) {
+        return true;
+    }
+
+    @Override
+    public void validate(Object target, Errors errors) {
+        if (errorFields != null) {
+            for (String field : errorFields) {
+                errors.rejectValue(field, "Test Error");
+            }
+        }
+    }
+}

--- a/jcommune-view/jcommune-web-controller/src/test/java/org/jtalks/jcommune/web/validation/ExistsValidatorTest.java
+++ b/jcommune-view/jcommune-web-controller/src/test/java/org/jtalks/jcommune/web/validation/ExistsValidatorTest.java
@@ -16,6 +16,7 @@ package org.jtalks.jcommune.web.validation;
 
 import org.jtalks.common.model.entity.Entity;
 import org.jtalks.jcommune.model.dao.ValidatorDao;
+import org.jtalks.jcommune.web.validation.annotations.Exists;
 import org.jtalks.jcommune.web.validation.validators.ExistenceValidator;
 import org.mockito.Matchers;
 import org.mockito.Mock;
@@ -38,6 +39,8 @@ public class ExistsValidatorTest {
     private ExistenceValidator validator;
     @Mock
     private ValidatorDao<String> dao;
+    @Mock
+    private Exists existsAnnotation;
 
     @BeforeMethod
     public void init() {
@@ -62,5 +65,13 @@ public class ExistsValidatorTest {
     @Test
     public void testNullValue() {
         assertFalse(validator.isValid(null, null));
+    }
+
+    @Test
+    public void testNullValueIfWhenNullableAllowed() {
+        when(existsAnnotation.isNullableAllowed()).thenReturn(true);
+        validator.initialize(existsAnnotation);
+
+        assertTrue(validator.isValid(null, null));
     }
 }

--- a/jcommune-view/jcommune-web-controller/src/test/java/org/jtalks/jcommune/web/validation/validators/AtLeastOneNotEmptyValidatorTest.java
+++ b/jcommune-view/jcommune-web-controller/src/test/java/org/jtalks/jcommune/web/validation/validators/AtLeastOneNotEmptyValidatorTest.java
@@ -1,0 +1,99 @@
+/**
+ * Copyright (C) 2011  JTalks.org Team
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+package org.jtalks.jcommune.web.validation.validators;
+
+import org.jtalks.jcommune.web.validation.annotations.AtLeastOneNotEmpty;
+import org.mockito.Mock;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import static org.mockito.Mockito.when;
+import static org.mockito.MockitoAnnotations.initMocks;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
+
+/**
+ * @author Mikhail Stryzhonok
+ */
+public class AtLeastOneNotEmptyValidatorTest {
+
+    @Mock
+    private AtLeastOneNotEmpty annotation;
+
+    @BeforeMethod
+    public void setUp() {
+        initMocks(this);
+    }
+
+    @Test
+    public void validationShouldNotPassIfAllFieldsNull() {
+        AtLeastOneNotEmptyValidator validator = new AtLeastOneNotEmptyValidator();
+
+        when(annotation.fieldNames()).thenReturn(new String[]{"field1", "field2"});
+        validator.initialize(annotation);
+
+        assertFalse(validator.isValid(new TestBean(null, null), null));
+    }
+
+    @Test
+    public void validationShouldNotPassIfAllFieldsEmpty() {
+        AtLeastOneNotEmptyValidator validator = new AtLeastOneNotEmptyValidator();
+
+        when(annotation.fieldNames()).thenReturn(new String[]{"field1", "field2"});
+        validator.initialize(annotation);
+
+        assertFalse(validator.isValid(new TestBean("     ", "     "), null));
+    }
+
+    @Test
+    public void validationShouldPassIfAtLeastOneFieldNotEmpty() {
+        AtLeastOneNotEmptyValidator validator = new AtLeastOneNotEmptyValidator();
+
+        when(annotation.fieldNames()).thenReturn(new String[]{"field1", "field2"});
+        validator.initialize(annotation);
+
+        assertTrue(validator.isValid(new TestBean("test", "     "), null));
+    }
+
+    @Test
+    public void validationShouldPassIfAtLeastOneFieldNotNull() {
+        AtLeastOneNotEmptyValidator validator = new AtLeastOneNotEmptyValidator();
+
+        when(annotation.fieldNames()).thenReturn(new String[]{"field1", "field2"});
+        validator.initialize(annotation);
+
+        assertTrue(validator.isValid(new TestBean("test", null), null));
+    }
+
+    @Test
+    public void validationShouldPassIfAllFieldsNotEmpty() {
+        AtLeastOneNotEmptyValidator validator = new AtLeastOneNotEmptyValidator();
+
+        when(annotation.fieldNames()).thenReturn(new String[]{"field1", "field2"});
+        validator.initialize(annotation);
+
+        assertTrue(validator.isValid(new TestBean("test", "test"), null));
+    }
+
+    private static class TestBean {
+        private String field1;
+        private String field2;
+
+        public TestBean(String field1, String field2) {
+            this.field1 = field1;
+            this.field2 = field2;
+        }
+    }
+}

--- a/jcommune-view/jcommune-web-controller/src/test/java/org/jtalks/jcommune/web/validation/validators/ValidatorStubTest.java
+++ b/jcommune-view/jcommune-web-controller/src/test/java/org/jtalks/jcommune/web/validation/validators/ValidatorStubTest.java
@@ -1,0 +1,85 @@
+/**
+ * Copyright (C) 2011  JTalks.org Team
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+package org.jtalks.jcommune.web.validation.validators;
+
+import org.springframework.validation.BeanPropertyBindingResult;
+import org.springframework.validation.Errors;
+import org.testng.annotations.Test;
+
+import static org.testng.AssertJUnit.assertEquals;
+import static org.testng.AssertJUnit.assertFalse;
+import static org.testng.AssertJUnit.assertTrue;
+
+/**
+ * @author Mikhail Stryzhonok
+ */
+public class ValidatorStubTest {
+
+    @Test
+    public void supportsShouldReturnTrue() {
+        ValidatorStub validator = new ValidatorStub();
+
+        assertTrue(validator.supports(Object.class));
+    }
+
+    @Test
+    public void validateShouldRejectAllSpecifiedFields() {
+        String[] fields = new String[]{"field1", "field2", "field3"};
+        ValidatorStub validator = new ValidatorStub(fields);
+        TestBean testObject = new TestBean();
+        Errors errors = new BeanPropertyBindingResult(testObject, "object");
+
+        validator.validate(testObject, errors);
+
+        assertEquals(3, errors.getErrorCount());
+        for (String field : fields) {
+            assertTrue("Errors should contain field error for " + field, errors.hasFieldErrors(field));
+        }
+    }
+
+    @Test
+    public void validateShouldNotRejectFieldsIfNoErrorFieldSpecified() {
+        ValidatorStub validator = new ValidatorStub();
+        TestBean testObject = new TestBean();
+        Errors errors = new BeanPropertyBindingResult(testObject, "object");
+
+        validator.validate(testObject, errors);
+
+        assertFalse(errors.hasErrors());
+    }
+
+    private static class TestBean {
+        private String field1;
+        private String field2;
+        private String field3;
+        private String field4;
+
+        public String getField1() {
+            return field1;
+        }
+
+        public String getField2() {
+            return field2;
+        }
+
+        public String getField3() {
+            return field3;
+        }
+
+        public String getField4() {
+            return field4;
+        }
+    }
+}

--- a/jcommune-view/jcommune-web-view/src/main/webapp/resources/css/app/application.css
+++ b/jcommune-view/jcommune-web-view/src/main/webapp/resources/css/app/application.css
@@ -1148,3 +1148,14 @@ pre.prettyprint {
     overflow: hidden;
     white-space: nowrap;
 }
+
+.custom-selected-item, .custom-selected-item a{
+    color: #ffffff !important;
+    text-decoration: none !important;
+    outline: 0 !important;
+    background-color: #428bca !important;
+    background-image: none !important;
+    border: none !important;
+    font-weight: normal !important;
+}
+

--- a/jcommune-view/jcommune-web-view/src/main/webapp/resources/javascript/app/contextMenu.js
+++ b/jcommune-view/jcommune-web-view/src/main/webapp/resources/javascript/app/contextMenu.js
@@ -21,6 +21,46 @@
  */
 
 jQuery(document).ready(function () {
+    var validOptions = [];
+    var recipientField = $('#recipient');
+    recipientField.autocomplete({
+        source : function(request, response) {
+            $.ajax({
+                type: 'POST',
+                url: baseUrl + '/usernames',
+                data: {pattern: recipientField.val()},
+                success: function (data) {
+                    if (data.result && data.result.length > 0) {
+                        validOptions = data.result;
+                        response(data.result);
+                    }
+                }
+            });
+        },
+        focus: function(e, ui) {
+            $(".ui-menu-item").removeClass("custom-selected-item");
+            $("#ui-active-menuitem").parent().addClass("custom-selected-item");
+            $("#ui-active-menuitem").removeClass("ui-corner-all");
+        }
+    });
+
+    recipientField.blur(function() {
+        clearRecipientIfIncorrect();
+    });
+
+    recipientField.keydown(function(e) {
+        if (e.ctrlKey && e.keyCode == enterCode) {
+            clearRecipientIfIncorrect();
+        }
+    });
+
+    function clearRecipientIfIncorrect() {
+        if (validOptions.indexOf(recipientField.val()) == -1) {
+            recipientField.val("");
+            toggleSaveButtonEnabled();
+        }
+    }
+
     var baseUrl = $root;
     //saved position of '@' character, -1 mean not exist
     var atPosition = -1;


### PR DESCRIPTION
Now drafts can be saved with only one field filled (not matter recipient, title or body):
      -Created separate DTO for drafts to perform specific validation rules

Added suggestion list to recipient field. Now if user types invalid recipient name recipient field will be cleared after leaving focus or before submitting form(if user press ctl + enter hotkey)

Created unit tests using Spring MockMvc