### PR TITLE
JC-1938 Incorrect text wrapping in tooltip on mouse over the ukrainian flag

### DIFF
--- a/jcommune-view/jcommune-web-view/src/main/webapp/resources/css/app/application.css
+++ b/jcommune-view/jcommune-web-view/src/main/webapp/resources/css/app/application.css
@@ -1090,7 +1090,11 @@ pre.prettyprint {
 
 #lang-selector-toggle-li .tooltip {
     white-space: pre-wrap;
-    max-width: 61px;
+    max-width: 71px;
+}
+
+#lang-selector-toggle-li .tooltip .tooltip-inner {
+    word-wrap: normal;
 }
 
 .full-width {


### PR DESCRIPTION
Edited CSS classes for tooltip block

This commit related on tasks JC-1938, JC-1939