### PR TITLE
JC-1959 Lowercase beginning of the hints in new article page (EN, SPA)

### DIFF
--- a/jcommune-view/jcommune-web-controller/src/main/resources/ValidationMessages_en.properties
+++ b/jcommune-view/jcommune-web-controller/src/main/resources/ValidationMessages_en.properties
@@ -1,3 +1,5 @@
+javax.validation.constraints.Size.message=Size must be between {min} and {max}
+#######################################################
 title.length=should be {min} - {max} characters
 body.length=should be {min} - {max} characters
 not_empty=can't be empty

--- a/jcommune-view/jcommune-web-controller/src/main/resources/ValidationMessages_es.properties
+++ b/jcommune-view/jcommune-web-controller/src/main/resources/ValidationMessages_es.properties
@@ -1,3 +1,5 @@
+javax.validation.constraints.Size.message=El tama\u00f1o tiene que estar entre {min} y {max}
+#######################################################
 title.length=debe tener {min} - {max} caracteres
 body.length=debe tener {min} - {max} caracteres
 not_empty=no puede estar vac\u00EDo


### PR DESCRIPTION
JC-1959 Lowercase beginning of the hints in new article page (EN, SPA)
JC-2087 Lower-case text in message error

Added message error with uppercase beginning of the hints in new article page (EN, SPA). Both issues are equals