### PR TITLE
Add separete groups and users with all branch permissions

### DIFF
--- a/jcommune-model/src/main/resources/org/jtalks/jcommune/model/sample-forum.sql
+++ b/jcommune-model/src/main/resources/org/jtalks/jcommune/model/sample-forum.sql
@@ -1,6 +1,6 @@
 ﻿SET @forum_component_id := 2;
 -- Update description of FORUM component for new users baing created
-update COMPONENTS set DESCRIPTION = 'Available users: admin/admin registered/registered moderator/moderator banned/banned'
+update COMPONENTS set DESCRIPTION = 'Available users: admin/admin registered/registered moderator/moderator banned/banned and others'
   where CMP_ID = @forum_component_id;
 
 insert ignore into SECTIONS (SECTION_ID, UUID, `NAME`, DESCRIPTION, POSITION, COMPONENT_ID) VALUES
@@ -13,25 +13,62 @@ insert ignore into SECTIONS (SECTION_ID, UUID, `NAME`, DESCRIPTION, POSITION, CO
   (7,(SELECT UUID() FROM dual),'TV', 'Has this zombobox something interesting?', 7, @forum_component_id),
   (8,(SELECT UUID() FROM dual),'Hi-tech', 'Technologies', 8, @forum_component_id),
   (9,(SELECT UUID() FROM dual),'People', 'All about mankind', 9, @forum_component_id),
-  (10,(SELECT UUID() FROM dual),'Leisure', 'Have free time?', 10, @forum_component_id);
+  (10,(select UUID() from dual),'Leisure', 'Have free time?', 10, @forum_component_id),
+  (11,(select UUID() from dual),'For Automated testing only', 'This Section is used for Automated testing only', 11, @forum_component_id),
+  (12,(select UUID() from dual),'Invisible section', 'Invisible section', 12, @forum_component_id);
   
 -- GROUPS BEGIN
 insert ignore into GROUPS (UUID, `NAME`, DESCRIPTION)
   select UUID(), 'Moderators', 'General group for all moderators'
   from dual
   where not exists (select GROUP_ID from GROUPS where `NAME` = 'Moderators');
+insert ignore into GROUPS (UUID, `NAME`) values 
+	((select UUID() from dual), 'createPosts'),
+	((select UUID() from dual), 'createStickedPosts'),
+	((select UUID() from dual), 'createAnnouncements'),
+	((select UUID() from dual), 'editOwnPosts'),
+	((select UUID() from dual), 'editOtherPosts'),
+	((select UUID() from dual), 'deleteOwnPosts'),
+	((select UUID() from dual), 'deleteOthersPosts'),
+	((select UUID() from dual), 'moveTopics'),
+	((select UUID() from dual), 'closeTopics'),
+	((select UUID() from dual), 'createCodeReview'),
+	((select UUID() from dual), 'leaveCommentsInCodeReview');
 
-SET @admin_group_id := (select GROUP_ID from GROUPS where `NAME`='Administrators');
-SET @registered_group_id := (select GROUP_ID from GROUPS where `NAME`='Registered Users');
-SET @banned_group_id := (select GROUP_ID from GROUPS where `NAME`='Banned Users');
-SET @moderator_group_id := (select GROUP_ID from GROUPS where `NAME`='Moderators');
+set @admin_group_id := (select GROUP_ID from GROUPS where `NAME`='Administrators');
+set @registered_group_id := (select GROUP_ID from GROUPS where `NAME`='Registered Users');
+set @banned_group_id := (select GROUP_ID from GROUPS where `NAME`='Banned Users');
+set @moderator_group_id := (select GROUP_ID from GROUPS where `NAME`='Moderators');
+set @createPosts_group_id = (select GROUP_ID from GROUPS where `NAME`='createPosts');
+set @createStickedPosts_group_id = (select GROUP_ID from GROUPS where `NAME`='createStickedPosts');
+set @createAnnouncements_group_id = (select GROUP_ID from GROUPS where `NAME`='createAnnouncements');
+set @editOwnPosts_group_id = (select GROUP_ID from GROUPS where `NAME`='editOwnPosts');
+set @editOtherPosts_group_id = (select GROUP_ID from GROUPS where `NAME`='editOtherPosts');
+set @deleteOwnPosts_group_id = (select GROUP_ID from GROUPS where `NAME`='deleteOwnPosts');
+set @deleteOthersPosts_group_id = (select GROUP_ID from GROUPS where `NAME`='deleteOthersPosts');
+set @moveTopics_group_id = (select GROUP_ID from GROUPS where `NAME`='moveTopics');
+set @closetopics_group_id = (select GROUP_ID from GROUPS where `NAME`='closeTopics');
+set @createCodeReview_group_id = (select GROUP_ID from GROUPS where `NAME`='createCodeReview');
+set @leaveCommentsInCodeReview_group_id = (select GROUP_ID from GROUPS where `NAME`='leaveCommentsInCodeReview');
 
-SET @admin_group_sid := concat('usergroup:',@admin_group_id);
-SET @registered_group_sid := concat('usergroup:',@registered_group_id);
-SET @banned_group_sid := concat('usergroup:',@banned_group_id);
-SET @moderator_group_sid := concat('usergroup:',@moderator_group_id);
+set @admin_group_sid := concat('usergroup:',@admin_group_id);
+set @registered_group_sid := concat('usergroup:',@registered_group_id);
+set @banned_group_sid := concat('usergroup:',@banned_group_id);
+set @moderator_group_sid := concat('usergroup:',@moderator_group_id);
+set @createPosts_group_sid = concat('usergroup:',@createPosts_group_id);
+set @createStickedPosts_group_sid = concat('usergroup:',@createStickedPosts_group_id);
+set @createAnnouncements_group_sid = concat('usergroup:',@createAnnouncements_group_id);
+set @editOwnPosts_group_sid = concat('usergroup:',@editOwnPosts_group_id);
+set @editOtherPosts_group_sid = concat('usergroup:',@editOtherPosts_group_id);
+set @deleteOwnPosts_group_sid = concat('usergroup:',@deleteOwnPosts_group_id);
+set @deleteOthersPosts_group_sid = concat('usergroup:',@deleteOthersPosts_group_id);
+set @moveTopics_group_sid = concat('usergroup:',@moveTopics_group_id);
+set @closetopics_group_sid = concat('usergroup:',@closetopics_group_id);
+set @createCodeReview_group_sid = concat('usergroup:',@createCodeReview_group_id);
+set @leaveCommentsInCodeReview_group_sid = concat('usergroup:',@leaveCommentsInCodeReview_group_id);
 -- GROUPS END
 
+-- BRANCHES BEGIN
 insert ignore into BRANCHES (BRANCH_ID, UUID, `NAME`, DESCRIPTION, POSITION, SECTION_ID, MODERATORS_GROUP_ID) VALUES
   (1, UUID(), 'Curling', 'Brooms and stones', 0, 1, 1),
   (2, UUID(), 'Cricet', 'Balls and bats', 1, 1 ,1),
@@ -90,7 +127,10 @@ insert ignore into BRANCHES (BRANCH_ID, UUID, `NAME`, DESCRIPTION, POSITION, SEC
   (46, UUID(), 'Theatre', 'Performances', 0, 10, 1),
   (47, UUID(), 'Cinema', 'New blockbusters', 1, 10 ,1),
   (48, UUID(), 'Exhibitions', 'Art', 2, 10 ,1),
-  (49, UUID(), 'Competitions', 'Some sport', 3, 10 ,1);
+  (49, UUID(), 'Competitions', 'Some sport', 3, 10 ,1),
+  (50, UUID(), 'Notification tests', 'All permissions for registered users', 0, 11 ,1),
+  (51, UUID(), 'Invisible Branch', 'used to check permission for admin', 0, 12, null);
+  -- BRANCHES END
 
 -- ****USERS CREATION BEGIN****
 -- Creates a default users with registered/registered, moderator/moderator, banned/banned credentials to be able to log in without manual registration
@@ -98,17 +138,50 @@ insert ignore into BRANCHES (BRANCH_ID, UUID, `NAME`, DESCRIPTION, POSITION, SEC
 insert ignore into USERS (UUID, USERNAME, ENCODED_USERNAME, EMAIL, PASSWORD, ROLE, SALT, ENABLED) VALUES
   ((SELECT UUID() FROM dual), 'registered', 'registered', 'registered@jtalks.org', MD5('registered'), 'USER_ROLE', '',true),
   ((SELECT UUID() FROM dual), 'moderator', 'moderator', 'moderator@jtalks.org', MD5('moderator'), 'USER_ROLE', '', true),
-  ((SELECT UUID() FROM dual), 'banned', 'banned', 'banned@jtalks.org', MD5('banned'), 'USER_ROLE', '', true);
+  ((SELECT UUID() FROM dual), 'banned', 'banned', 'banned@jtalks.org', MD5('banned'), 'USER_ROLE', '', true),
+  ((select UUID() from dual), 'post_creator', 'post_creator', 'post_creator@jtalks.org', MD5('qwerty'), 'USER_ROLE', '',true),
+  ((select UUID() from dual), 'sticked_post_creator', 'sticked_post_creator', 'sticked_post_creator@jtalks.org', MD5('qwerty'), 'USER_ROLE', '',true),
+  ((select UUID() from dual), 'announcement_creator', 'announcement_creator', 'announcement_creator@jtalks.org', MD5('qwerty'), 'USER_ROLE', '',true),
+  ((select UUID() from dual), 'ownpost_editor', 'ownpost_editor', 'ownpost_editor@jtalks.org', MD5('qwerty'), 'USER_ROLE', '',true),
+  ((select UUID() from dual), 'otherpost_editor', 'otherpost_editor', 'otherpost_editor@jtalks.org', MD5('qwerty'), 'USER_ROLE', '',true),
+  ((select UUID() from dual), 'ownpost_remover', 'ownpost_remover', 'ownpost_remover@jtalks.org', MD5('qwerty'), 'USER_ROLE', '',true),
+  ((select UUID() from dual), 'otherpost_remover', 'otherpost_remover', 'otherpost_remover@jtalks.org', MD5('qwerty'), 'USER_ROLE', '',true),
+  ((select UUID() from dual), 'topic_mover', 'topic_mover', 'topic_mover@jtalks.org', MD5('qwerty'), 'USER_ROLE', '',true),
+  ((select UUID() from dual), 'topic_closer', 'topic_closer', 'topic_closer@jtalks.org', MD5('qwerty'), 'USER_ROLE', '',true),
+  ((select UUID() from dual), 'codeReview_creator', 'codeReview_creator', 'codeReview_creator@jtalks.org', MD5('qwerty'), 'USER_ROLE', '',true),
+  ((select UUID() from dual), 'codeReview_commentator', 'codeReview_commentator', 'codeReview_commentator@jtalks.org', MD5('qwerty'), 'USER_ROLE', '',true);
 insert ignore into JC_USER_DETAILS (USER_ID, REGISTRATION_DATE, POST_COUNT) values
   ((select ID from USERS where USERNAME = 'registered'), NOW(), 0),
   ((select ID from USERS where USERNAME = 'moderator'), NOW(), 0),
-  ((select ID from USERS where USERNAME = 'banned'), NOW(), 0) ;
+  ((select ID from USERS where USERNAME = 'banned'), NOW(), 0),
+  ((select ID from USERS where USERNAME = 'post_creator'), NOW(), 0),
+  ((select ID from USERS where USERNAME = 'sticked_post_creator'), NOW(), 0),
+  ((select ID from USERS where USERNAME = 'announcement_creator'), NOW(), 0),
+  ((select ID from USERS where USERNAME = 'ownpost_editor'), NOW(), 0),
+  ((select ID from USERS where USERNAME = 'otherpost_editor'), NOW(), 0),
+  ((select ID from USERS where USERNAME = 'ownpost_remover'), NOW(), 0),
+  ((select ID from USERS where USERNAME = 'otherpost_remover'), NOW(), 0),
+  ((select ID from USERS where USERNAME = 'topic_mover'), NOW(), 0),
+  ((select ID from USERS where USERNAME = 'topic_closer'), NOW(), 0),
+  ((select ID from USERS where USERNAME = 'codeReview_creator'), NOW(), 0),
+  ((select ID from USERS where USERNAME = 'codeReview_commentator'), NOW(), 0);
 -- ****USERS CREATION END****
 
 -- Add users to appropriate groups
 insert ignore into GROUP_USER_REF select @registered_group_id, ID from USERS;
 insert ignore into GROUP_USER_REF select @moderator_group_id, ID from USERS where USERNAME in ('moderator', 'admin');
 insert ignore into GROUP_USER_REF select @banned_group_id, ID from USERS where USERNAME = 'banned';
+insert ignore into GROUP_USER_REF select @createPosts_group_id, ID from USERS where USERNAME = 'post_creator';
+insert ignore into GROUP_USER_REF select @createStickedPosts_group_id, ID from USERS where USERNAME = 'sticked_post_creator';
+insert ignore into GROUP_USER_REF select @createAnnouncements_group_id, ID from USERS where USERNAME = 'announcement_creator';
+insert ignore into GROUP_USER_REF select @editOwnPosts_group_id, ID from USERS where USERNAME = 'ownpost_editor';
+insert ignore into GROUP_USER_REF select @editOtherPosts_group_id, ID from USERS where USERNAME = 'otherpost_editor';
+insert ignore into GROUP_USER_REF select @deleteOwnPosts_group_id, ID from USERS where USERNAME = 'ownpost_remover';
+insert ignore into GROUP_USER_REF select @deleteOthersPosts_group_id, ID from USERS where USERNAME = 'otherpost_remover';
+insert ignore into GROUP_USER_REF select @moveTopics_group_id, ID from USERS where USERNAME = 'topic_mover';
+insert ignore into GROUP_USER_REF select @closetopics_group_id, ID from USERS where USERNAME = 'topic_closer';
+insert ignore into GROUP_USER_REF select @createCodeReview_group_id, ID from USERS where USERNAME = 'codeReview_creator';
+insert ignore into GROUP_USER_REF select @leaveCommentsInCodeReview_group_id, ID from USERS where USERNAME = 'codeReview_commentator';
 
 set @component_acl_class=1;
 set @group_acl_class=2;
@@ -116,37 +189,59 @@ set @branch_acl_class=3;
 insert ignore into acl_class values (@branch_acl_class,'BRANCH'), (@group_acl_class,'GROUP'), (@component_acl_class,'COMPONENT');
 
 insert into acl_sid(principal, sid) values (0, @moderator_group_sid);
+insert into acl_sid(principal, sid) values (0, @createPosts_group_sid);
+insert into acl_sid(principal, sid) values (0, @createStickedPosts_group_sid);
+insert into acl_sid(principal, sid) values (0, @createAnnouncements_group_sid);
+insert into acl_sid(principal, sid) values (0, @editOwnPosts_group_sid);
+insert into acl_sid(principal, sid) values (0, @editOtherPosts_group_sid);
+insert into acl_sid(principal, sid) values (0, @deleteOwnPosts_group_sid);
+insert into acl_sid(principal, sid) values (0, @deleteOthersPosts_group_sid);
+insert into acl_sid(principal, sid) values (0, @moveTopics_group_sid);
+insert into acl_sid(principal, sid) values (0, @closetopics_group_sid);
+insert into acl_sid(principal, sid) values (0, @createCodeReview_group_sid);
+insert into acl_sid(principal, sid) values (0, @leaveCommentsInCodeReview_group_sid);
 
-SET @admin_group_sid_id := (select id from acl_sid where sid=@admin_group_sid);
-SET @registered_group_sid_id := (select id from acl_sid where sid=@registered_group_sid);
-SET @banned_group_sid_id := (select id from acl_sid where sid=@banned_group_sid);
-SET @moderator_group_sid_id := (select id from acl_sid where sid=@moderator_group_sid);
-SET @anonymous_sid_id := (select id from acl_sid where sid='user:anonymousUser');
+set @admin_group_sid_id := (select id from acl_sid where sid=@admin_group_sid);
+set @registered_group_sid_id := (select id from acl_sid where sid=@registered_group_sid);
+set @banned_group_sid_id := (select id from acl_sid where sid=@banned_group_sid);
+set @moderator_group_sid_id := (select id from acl_sid where sid=@moderator_group_sid);
+set @anonymous_sid_id := (select id from acl_sid where sid='user:anonymousUser');
+set @createPosts_group_sid_id = (select id from acl_sid where sid=@createPosts_group_sid);
+set @createStickedPosts_group_sid_id = (select id from acl_sid where sid=@createStickedPosts_group_sid);
+set @createAnnouncements_group_sid_id = (select id from acl_sid where sid=@createAnnouncements_group_sid);
+set @editOwnPosts_group_sid_id = (select id from acl_sid where sid=@editOwnPosts_group_sid);
+set @editOtherPosts_group_sid_id = (select id from acl_sid where sid=@editOtherPosts_group_sid);
+set @deleteOwnPosts_group_sid_id = (select id from acl_sid where sid=@deleteOwnPosts_group_sid);
+set @deleteOthersPosts_group_sid_id = (select id from acl_sid where sid=@deleteOthersPosts_group_sid);
+set @moveTopics_group_sid_id = (select id from acl_sid where sid=@moveTopics_group_sid);
+set @closetopics_group_sid_id = (select id from acl_sid where sid=@closetopics_group_sid);
+set @createCodeReview_group_sid_id = (select id from acl_sid where sid=@createCodeReview_group_sid);
+set @leaveCommentsInCodeReview_group_sid_id = (select id from acl_sid where sid=@leaveCommentsInCodeReview_group_sid);
 
 -- PERMISSIONS BEGIN
-SET @SEND_PRIVATE_MESSAGES_MASK := 14;
-SET @CREATE_FORUM_FAQ_MASK := 20;
-SET @EDIT_OWN_PROFILE_MASK := 15;
-SET @EDIT_OTHERS_PROFILE_MASK := 23;
+set @SEND_PRIVATE_MESSAGES_MASK := 14;
+set @CREATE_FORUM_FAQ_MASK := 20;
+set @EDIT_OWN_PROFILE_MASK := 15;
+set @EDIT_OTHERS_PROFILE_MASK := 23;
 
-SET @VIEW_TOPICS_MASK := 6;
-SET @MOVE_TOPICS_MASK := 8;
-SET @CLOSE_TOPICS_MASK := 11;
-SET @CREATE_POSTS_MASK := 12;
-SET @DELETE_OWN_POSTS_MASK := 7;
-SET @DELETE_OTHERS_POSTS_MASK := 13;
-SET @EDIT_OWN_POSTS_MASK := 133;
-SET @EDIT_OTHERS_POSTS_MASK := 17;
-SET @CREATE_ANNOUNCEMENTS_MASK := 18;
-SET @CREATE_STICKED_TOPICS_MASK := 19;
-SET @CREATE_CODE_REVIEW_MASK := 21;
-SET @LEAVE_COMMENTS_IN_CODE_REVIEW_MASK := 22;
+set @VIEW_TOPICS_MASK := 6;
+set @MOVE_TOPICS_MASK := 8;
+set @CLOSE_TOPICS_MASK := 11;
+set @CREATE_POSTS_MASK := 12;
+set @DELETE_OWN_POSTS_MASK := 7;
+set @DELETE_OTHERS_POSTS_MASK := 13;
+set @EDIT_OWN_POSTS_MASK := 133;
+set @EDIT_OTHERS_POSTS_MASK := 17;
+set @CREATE_ANNOUNCEMENTS_MASK := 18;
+set @CREATE_STICKED_TOPICS_MASK := 19;
+set @CREATE_CODE_REVIEW_MASK := 21;
+set @LEAVE_COMMENTS_IN_CODE_REVIEW_MASK := 22;
 
-SET @ADMIN_MASK := 16;
+set @ADMIN_MASK := 16;
 -- PERMISSIONS END
 
 --  Records for branches will start from this ID+1 in acl_object_identity table
-SET @branches_acl_object_identity_id_start = (SELECT MAX(ID) FROM acl_object_identity);
+set @branches_acl_object_identity_id_start = (SELECT MAX(ID) FROM acl_object_identity);
 
 insert into acl_object_identity
  SELECT @branches_acl_object_identity_id_start + BranchTable.BRANCH_ID, @branch_acl_class, BranchTable.BRANCH_ID, NULL, 1, 1
@@ -157,6 +252,17 @@ set @branches_count = (SELECT COUNT(*) FROM BRANCHES);
 set @registered_group_object_identity=@branches_acl_object_identity_id_start + @branches_count + 1;
 set @admin_group_object_identity=@branches_acl_object_identity_id_start + @branches_count + 2;
 set @banned_group_object_identity=@branches_acl_object_identity_id_start + @branches_count + 3;
+set @createPosts_group_object_identity=@branches_acl_object_identity_id_start + @branches_count + 5;
+set @createStickedPosts_group_object_identity=@branches_acl_object_identity_id_start + @branches_count + 6;
+set @createAnnouncements_group_object_identity=@branches_acl_object_identity_id_start + @branches_count + 7;
+set @editOwnPosts_group_object_identity=@branches_acl_object_identity_id_start + @branches_count + 8;
+set @editOtherPosts_group_object_identity=@branches_acl_object_identity_id_start + @branches_count + 9;
+set @deleteOwnPosts_group_object_identity=@branches_acl_object_identity_id_start + @branches_count + 10;
+set @deleteOthersPosts_group_object_identity=@branches_acl_object_identity_id_start + @branches_count + 11;
+set @moveTopics_group_object_identity=@branches_acl_object_identity_id_start + @branches_count + 12;
+set @closetopics_group_object_identity=@branches_acl_object_identity_id_start + @branches_count + 13;
+set @createCodeReview_group_object_identity=@branches_acl_object_identity_id_start + @branches_count + 14;
+set @leaveCommentsInCodeReview_group_object_identity=@branches_acl_object_identity_id_start + @branches_count + 15;
 
 insert into acl_object_identity values
   (@registered_group_object_identity, @group_acl_class, @registered_group_id, NULL, 1, 1),
@@ -207,6 +313,85 @@ insert into acl_entry (acl_object_identity, ace_order, sid, mask, granting, audi
   select @branches_acl_object_identity_id_start + BRANCH_ID, 1019, @banned_group_sid_id, @CREATE_CODE_REVIEW_MASK, 0, 0, 0 from BRANCHES;
 insert into acl_entry (acl_object_identity, ace_order, sid, mask, granting, audit_success, audit_failure)
   select @branches_acl_object_identity_id_start + BRANCH_ID, 1020, @banned_group_sid_id, @VIEW_TOPICS_MASK, 0, 0, 0 from BRANCHES;
+
+-- setting permissions for createPosts users on all branches
+insert into acl_entry (acl_object_identity, ace_order, sid, mask, granting, audit_success, audit_failure) 
+  select @branches_acl_object_identity_id_start + BRANCH_ID, 1022, @createPosts_group_sid_id, @VIEW_TOPICS_MASK, 1, 0, 0 from BRANCHES;
+insert into acl_entry (acl_object_identity, ace_order, sid, mask, granting, audit_success, audit_failure) 
+  select @branches_acl_object_identity_id_start + BRANCH_ID, 1023, @createPosts_group_sid_id, @CREATE_POSTS_MASK, 1, 0, 0 from BRANCHES;
+
+ -- setting permissions for createStickedPosts users on all branches
+insert into acl_entry (acl_object_identity, ace_order, sid, mask, granting, audit_success, audit_failure) 
+  select @branches_acl_object_identity_id_start + BRANCH_ID, 1024, @createStickedPosts_group_sid_id, @VIEW_TOPICS_MASK, 1, 0, 0 from BRANCHES;
+insert into acl_entry (acl_object_identity, ace_order, sid, mask, granting, audit_success, audit_failure) 
+  select @branches_acl_object_identity_id_start + BRANCH_ID, 1025, @createStickedPosts_group_sid_id, @CREATE_POSTS_MASK, 1, 0, 0 from BRANCHES;
+insert into acl_entry (acl_object_identity, ace_order, sid, mask, granting, audit_success, audit_failure) 
+  select @branches_acl_object_identity_id_start + BRANCH_ID, 1026, @createStickedPosts_group_sid_id, @CREATE_STICKED_TOPICS_MASK, 1, 0, 0 from BRANCHES;
+
+ -- setting permissions for createAnnouncements users on all branches
+insert into acl_entry (acl_object_identity, ace_order, sid, mask, granting, audit_success, audit_failure) 
+  select @branches_acl_object_identity_id_start + BRANCH_ID, 1027, @createAnnouncements_group_sid_id, @VIEW_TOPICS_MASK, 1, 0, 0 from BRANCHES;
+insert into acl_entry (acl_object_identity, ace_order, sid, mask, granting, audit_success, audit_failure) 
+  select @branches_acl_object_identity_id_start + BRANCH_ID, 1028, @createAnnouncements_group_sid_id, @CREATE_POSTS_MASK, 1, 0, 0 from BRANCHES;
+insert into acl_entry (acl_object_identity, ace_order, sid, mask, granting, audit_success, audit_failure) 
+  select @branches_acl_object_identity_id_start + BRANCH_ID, 1029, @createAnnouncements_group_sid_id, @CREATE_ANNOUNCEMENTS_MASK, 1, 0, 0 from BRANCHES;
+
+-- setting permissions for editOwnPosts users on all branches
+insert into acl_entry (acl_object_identity, ace_order, sid, mask, granting, audit_success, audit_failure) 
+  select @branches_acl_object_identity_id_start + BRANCH_ID, 1030, @editOwnPosts_group_sid_id, @VIEW_TOPICS_MASK, 1, 0, 0 from BRANCHES;
+insert into acl_entry (acl_object_identity, ace_order, sid, mask, granting, audit_success, audit_failure) 
+  select @branches_acl_object_identity_id_start + BRANCH_ID, 1031, @editOwnPosts_group_sid_id, @CREATE_POSTS_MASK, 1, 0, 0 from BRANCHES;
+insert into acl_entry (acl_object_identity, ace_order, sid, mask, granting, audit_success, audit_failure) 
+  select @branches_acl_object_identity_id_start + BRANCH_ID, 1032, @editOwnPosts_group_sid_id, @EDIT_OWN_POSTS_MASK, 1, 0, 0 from BRANCHES;
+
+-- setting permissions for editOtherPosts users on all branches
+insert into acl_entry (acl_object_identity, ace_order, sid, mask, granting, audit_success, audit_failure) 
+  select @branches_acl_object_identity_id_start + BRANCH_ID, 1033, @editOtherPosts_group_sid_id, @VIEW_TOPICS_MASK, 1, 0, 0 from BRANCHES;
+insert into acl_entry (acl_object_identity, ace_order, sid, mask, granting, audit_success, audit_failure) 
+  select @branches_acl_object_identity_id_start + BRANCH_ID, 1034, @editOtherPosts_group_sid_id, @EDIT_OTHERS_POSTS_MASK, 1, 0, 0 from BRANCHES;
+
+-- setting permissions for deleteOwnPosts users on all branches
+insert into acl_entry (acl_object_identity, ace_order, sid, mask, granting, audit_success, audit_failure) 
+  select @branches_acl_object_identity_id_start + BRANCH_ID, 1035, @deleteOwnPosts_group_sid_id, @VIEW_TOPICS_MASK, 1, 0, 0 from BRANCHES;
+insert into acl_entry (acl_object_identity, ace_order, sid, mask, granting, audit_success, audit_failure) 
+  select @branches_acl_object_identity_id_start + BRANCH_ID, 1036, @deleteOwnPosts_group_sid_id, @CREATE_POSTS_MASK, 1, 0, 0 from BRANCHES;
+insert into acl_entry (acl_object_identity, ace_order, sid, mask, granting, audit_success, audit_failure) 
+  select @branches_acl_object_identity_id_start + BRANCH_ID, 1037, @deleteOwnPosts_group_sid_id, @DELETE_OWN_POSTS_MASK, 1, 0, 0 from BRANCHES;
+
+-- setting permissions for deleteOtherPosts users on all branches
+insert into acl_entry (acl_object_identity, ace_order, sid, mask, granting, audit_success, audit_failure) 
+  select @branches_acl_object_identity_id_start + BRANCH_ID, 1038, @deleteOthersPosts_group_sid_id, @VIEW_TOPICS_MASK, 1, 0, 0 from BRANCHES;
+insert into acl_entry (acl_object_identity, ace_order, sid, mask, granting, audit_success, audit_failure) 
+  select @branches_acl_object_identity_id_start + BRANCH_ID, 1039, @deleteOthersPosts_group_sid_id, @CREATE_POSTS_MASK, 1, 0, 0 from BRANCHES;
+insert into acl_entry (acl_object_identity, ace_order, sid, mask, granting, audit_success, audit_failure) 
+  select @branches_acl_object_identity_id_start + BRANCH_ID, 1040, @deleteOthersPosts_group_sid_id, @DELETE_OTHERS_POSTS_MASK, 1, 0, 0 from BRANCHES;
+
+-- setting permissions for moveTopics users on all branches
+insert into acl_entry (acl_object_identity, ace_order, sid, mask, granting, audit_success, audit_failure) 
+  select @branches_acl_object_identity_id_start + BRANCH_ID, 1041, @moveTopics_group_sid_id, @VIEW_TOPICS_MASK, 1, 0, 0 from BRANCHES;
+insert into acl_entry (acl_object_identity, ace_order, sid, mask, granting, audit_success, audit_failure) 
+  select @branches_acl_object_identity_id_start + BRANCH_ID, 1042, @moveTopics_group_sid_id, @MOVE_TOPICS_MASK, 1, 0, 0 from BRANCHES;
+
+-- setting permissions for closetopics users on all branches
+insert into acl_entry (acl_object_identity, ace_order, sid, mask, granting, audit_success, audit_failure) 
+  select @branches_acl_object_identity_id_start + BRANCH_ID, 1043, @closetopics_group_sid_id, @VIEW_TOPICS_MASK, 1, 0, 0 from BRANCHES;
+insert into acl_entry (acl_object_identity, ace_order, sid, mask, granting, audit_success, audit_failure) 
+  select @branches_acl_object_identity_id_start + BRANCH_ID, 1044, @closetopics_group_sid_id, @CLOSE_TOPICS_MASK, 1, 0, 0 from BRANCHES;
+
+-- setting permissions for createCodeReview users on all branches
+insert into acl_entry (acl_object_identity, ace_order, sid, mask, granting, audit_success, audit_failure) 
+  select @branches_acl_object_identity_id_start + BRANCH_ID, 1045, @createCodeReview_group_sid_id, @VIEW_TOPICS_MASK, 1, 0, 0 from BRANCHES;
+insert into acl_entry (acl_object_identity, ace_order, sid, mask, granting, audit_success, audit_failure) 
+  select @branches_acl_object_identity_id_start + BRANCH_ID, 1046, @createCodeReview_group_sid_id, @CREATE_CODE_REVIEW_MASK, 1, 0, 0 from BRANCHES;
+
+-- setting permissions for leaveCommentsInCodeReview users on all branches
+insert into acl_entry (acl_object_identity, ace_order, sid, mask, granting, audit_success, audit_failure) 
+  select @branches_acl_object_identity_id_start + BRANCH_ID, 1047, @leaveCommentsInCodeReview_group_sid_id, @VIEW_TOPICS_MASK, 1, 0, 0 from BRANCHES;
+insert into acl_entry (acl_object_identity, ace_order, sid, mask, granting, audit_success, audit_failure) 
+  select @branches_acl_object_identity_id_start + BRANCH_ID, 1048, @leaveCommentsInCodeReview_group_sid_id, @LEAVE_COMMENTS_IN_CODE_REVIEW_MASK, 1, 0, 0 from BRANCHES;
+
+-- deleting all permissions for all user groups from BRANCH_ID = 51
+delete from acl_entry where acl_object_identity = @branches_acl_object_identity_id_start + 51;
   
 -- personal permissions
 insert into acl_entry (acl_object_identity, ace_order, sid, mask, granting, audit_success, audit_failure)


### PR DESCRIPTION
Add code which allows to create separate groups, users,
adding users into appropriate group, assigning appropriate branch
permissions for appropriate group
This commit allows to use this script in automation tests for branch
permission testing

Add separate Sections and branches for automated test only and invisible
one

Next Step: add group and user for CREATE_QUESTIONS permission
Q/A feature is ready

MERGED from
https://github.com/AndreySurzhan/jcommune/commit/34672e3c21ef494a9d59f3b2be137976861683a9