### PR TITLE
JC-2130

### DIFF
--- a/jcommune-view/jcommune-web-view/src/main/webapp/resources/css/app/application.css
+++ b/jcommune-view/jcommune-web-view/src/main/webapp/resources/css/app/application.css
@@ -775,6 +775,25 @@ div.signup {
     white-space: nowrap;
 }
 
+
+.btn-group .btn:last-of-type {
+    -webkit-border-top-right-radius: 4px;
+    -moz-border-radius-topright: 4px;
+    border-top-right-radius: 4px;
+    -webkit-border-bottom-right-radius: 4px;
+    -moz-border-radius-bottomright: 4px;
+    border-bottom-right-radius: 4px;
+}
+
+.btn-group .btn.large:last-of-type {
+    -webkit-border-top-right-radius: 6px;
+    -moz-border-radius-topright: 6px;
+    border-top-right-radius: 6px;
+    -webkit-border-bottom-right-radius: 6px;
+    -moz-border-radius-bottomright: 6px;
+    border-bottom-right-radius: 6px;
+}
+
 .btn-with-dropdown .tooltip {
     display: inline-block;
     width: -moz-max-content;  /*firefox*/
@@ -1177,4 +1196,3 @@ pre.prettyprint {
     font-size: 13px !important;
     line-height: 1.2em !important;
 }
-

--- a/jcommune-view/jcommune-web-view/src/main/webapp/resources/css/lib/bootstrap.css
+++ b/jcommune-view/jcommune-web-view/src/main/webapp/resources/css/lib/bootstrap.css
@@ -2514,7 +2514,7 @@ button.btn.small, input[type="submit"].btn.small {
     border-bottom-left-radius: 4px;
 }
 
-.btn-group .btn:last-child, .btn-group .dropdown-toggle {
+.btn-group .btn:last-of-type, .btn-group .dropdown-toggle {
     -webkit-border-top-right-radius: 4px;
     -moz-border-radius-topright: 4px;
     border-top-right-radius: 4px;
@@ -2533,7 +2533,7 @@ button.btn.small, input[type="submit"].btn.small {
     border-bottom-left-radius: 6px;
 }
 
-.btn-group .btn.large:last-child, .btn-group .large.dropdown-toggle {
+.btn-group .btn.large:last-of-type, .btn-group .large.dropdown-toggle {
     -webkit-border-top-right-radius: 6px;
     -moz-border-radius-topright: 6px;
     border-top-right-radius: 6px;

--- a/jcommune-view/jcommune-web-view/src/main/webapp/resources/css/lib/bootstrap.css
+++ b/jcommune-view/jcommune-web-view/src/main/webapp/resources/css/lib/bootstrap.css
@@ -2514,7 +2514,7 @@ button.btn.small, input[type="submit"].btn.small {
     border-bottom-left-radius: 4px;
 }
 
-.btn-group .btn:last-of-type, .btn-group .dropdown-toggle {
+.btn-group .btn:last-child, .btn-group .dropdown-toggle {
     -webkit-border-top-right-radius: 4px;
     -moz-border-radius-topright: 4px;
     border-top-right-radius: 4px;
@@ -2533,7 +2533,7 @@ button.btn.small, input[type="submit"].btn.small {
     border-bottom-left-radius: 6px;
 }
 
-.btn-group .btn.large:last-of-type, .btn-group .large.dropdown-toggle {
+.btn-group .btn.large:last-child, .btn-group .large.dropdown-toggle {
     -webkit-border-top-right-radius: 6px;
     -moz-border-radius-topright: 6px;
     border-top-right-radius: 6px;


### PR DESCRIPTION
1)I can't repeat bug with white crossing line in firefox after last commits ;

2) Disappearing corners of 'delete', 'quote' buttons fixed
Problem was in .btn-group .btn.large:last-child(bootstrap.css) selector.
 It doesn't work when tooltip created, because it is not last child of .btn-group element.
 I chose :last-of-type instead of :last-child.

