### PR TITLE
JC-2130 Disappearing corners of 'delete', 'quote' buttons fixed

### DIFF
--- a/jcommune-view/jcommune-web-view/src/main/webapp/resources/css/app/application.css
+++ b/jcommune-view/jcommune-web-view/src/main/webapp/resources/css/app/application.css
@@ -775,6 +775,25 @@ div.signup {
     white-space: nowrap;
 }
 
+
+.btn-group .btn:last-of-type {
+    -webkit-border-top-right-radius: 4px;
+    -moz-border-radius-topright: 4px;
+    border-top-right-radius: 4px;
+    -webkit-border-bottom-right-radius: 4px;
+    -moz-border-radius-bottomright: 4px;
+    border-bottom-right-radius: 4px;
+}
+
+.btn-group .btn.large:last-of-type {
+    -webkit-border-top-right-radius: 6px;
+    -moz-border-radius-topright: 6px;
+    border-top-right-radius: 6px;
+    -webkit-border-bottom-right-radius: 6px;
+    -moz-border-radius-bottomright: 6px;
+    border-bottom-right-radius: 6px;
+}
+
 .btn-with-dropdown .tooltip {
     display: inline-block;
     width: -moz-max-content;  /*firefox*/
@@ -1177,4 +1196,3 @@ pre.prettyprint {
     font-size: 13px !important;
     line-height: 1.2em !important;
 }
-


### PR DESCRIPTION
Problem was in .btn-group .btn:last-child(bootstrap.css) selector.
It doesn't work when tooltip created,
because button isn't last child of .btn-group element after tooltip
creation. I overwrited this style in application.css with
:last-of-type pseudoclass