### PR TITLE
JC-1959 Lowercase beginning of the hints in new article page (EN, SPA)

### DIFF
--- a/jcommune-service/src/test/resources/ValidationMessages_en.properties
+++ b/jcommune-service/src/test/resources/ValidationMessages_en.properties
@@ -1,6 +1,6 @@
-title.length=should be {min} - {max} characters
-body.length=should be {min} - {max} characters
-not_empty=can't be empty
+title.length=Size must be between {min} - {max} characters
+body.length=Size must be between {min} - {max} characters
+not_empty=Can't be empty
 validation.not_null=Must not be empty
 password_not_matches=Password and confirmation password do not match
 user.email.illegal_length=Email field should not contain more than {max} symbols

--- a/jcommune-view/jcommune-web-controller/src/main/resources/ValidationMessages_en.properties
+++ b/jcommune-view/jcommune-web-controller/src/main/resources/ValidationMessages_en.properties
@@ -1,7 +1,5 @@
-javax.validation.constraints.Size.message=Size must be between {min} and {max}
-#######################################################
-title.length=should be {min} - {max} characters
-body.length=should be {min} - {max} characters
+title.length=Size must be between {min} - {max} characters
+body.length=Size must be between {min} - {max} characters
 not_empty=Can't be empty
 validation.not_null=Must not be empty
 password_not_matches=Password and confirmation password do not match


### PR DESCRIPTION
Two validation messages properties files were changed. Only one letter was
changed from lowercase to uppercase.
Also unnecessary validation constrain was removed: -javax.validation.constraints.Size.message=Size must be between {min} and {max}		+title.length=Size must be between {min} - {max} characters
-#######################################################
