### PR TITLE
JC-1959 Lowercase beginning of the hints in new article page (EN, SPA)

### DIFF
--- a/jcommune-view/jcommune-web-controller/src/main/resources/ValidationMessages_en.properties
+++ b/jcommune-view/jcommune-web-controller/src/main/resources/ValidationMessages_en.properties
@@ -1,3 +1,5 @@
+javax.validation.constraints.Size.message=Size must be between {min} and {max}
+#######################################################
 title.length=Size must be between {min} - {max} characters
 body.length=Size must be between {min} - {max} characters
 not_empty=Can't be empty


### PR DESCRIPTION
Return usefull line "javax.validation.constraints.Size.message=Size must
be between {min} and {max}" of
D:\Java\Projects\jcommune\jcommune-view\jcommune-web-controller\src\main\resources\ValidationMessages_en.properties