### PR TITLE
JC-1269 Allow deleting own topic if others didn't answer

### DIFF
--- a/jcommune-model/src/main/java/org/jtalks/jcommune/model/entity/Topic.java
+++ b/jcommune-model/src/main/java/org/jtalks/jcommune/model/entity/Topic.java
@@ -785,4 +785,18 @@ public class Topic extends Entity implements SubscriptionAwareEntity {
     public int getDisplayedPostsCount() {
         return getDisplayedPosts().size();
     }
+
+	/**
+	 * Checks if this topic contains only posts added by topic Owner.
+	 *
+	 * @return <code>true</code> if condition is followed, otherwise <code>false</code>
+	 */
+	public boolean isContainsOwnerPostsOnly() {
+		for (Post post : getDisplayedPosts()) {
+			if (!post.getUserCreated().equals(topicStarter)) {
+				return false;
+			}
+		}
+		return true;
+	}
 }

--- a/jcommune-model/src/test/java/org/jtalks/jcommune/model/entity/TopicTest.java
+++ b/jcommune-model/src/test/java/org/jtalks/jcommune/model/entity/TopicTest.java
@@ -17,10 +17,7 @@ package org.jtalks.jcommune.model.entity;
 import org.joda.time.DateTime;
 import org.testng.annotations.Test;
 
-import java.util.Arrays;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
+import java.util.*;
 
 import static org.testng.Assert.*;
 
@@ -480,14 +477,59 @@ public class TopicTest {
         assertEquals(topic.getLastDisplayedPost(), topic.getPosts().get(0));
     }
 
+	@Test
+	public void testIsContainsOwnerPostsOnlyReturnsTrueIfOthersDidNotRespond() {
+		Topic topic = createTopic();
+
+		assertTrue(topic.getPosts().size() > 0);
+		assertTrue(topic.isContainsOwnerPostsOnly());
+	}
+
+	@Test
+	public void testIsContainsOwnerPostsOnlyReturnsFalseIfOthersHaveResponded() {
+		Topic topic = createTopicWithOthersPosts();
+
+		assertTrue(topic.getPosts().size() > 0);
+		assertFalse(topic.isContainsOwnerPostsOnly());
+	}
+
+	@Test
+	public void testIsContainsOwnerPostsOnlyReturnsTrueOnEmptyTopic() {
+		Topic topic = createTopicWithOthersPosts();
+		topic.setPosts(Collections.<Post>emptyList());
+
+		assertTrue(topic.getPosts().size() == 0);
+		assertTrue(topic.isContainsOwnerPostsOnly());
+	}
+
     private Topic createTopic() {
-        Post post1 = new Post();
+		JCUser topicStarter = new JCUser();
+
+        Post post1 = new Post(topicStarter, "Post N1 for tests");
         post1.setCreationDate(new DateTime());
-        Post post2 = new Post();
-        post2.setCreationDate(new DateTime());
-        Topic topic = new Topic(new JCUser(), "title");
+		Post post2 = new Post(topicStarter, "Post N2 for tests");
+		post2.setCreationDate(new DateTime());
+
+        Topic topic = new Topic(topicStarter, "Topic title for testing");
         topic.addPost(post1);
         topic.addPost(post2);
+
         return topic;
     }
+
+	private Topic createTopicWithOthersPosts() {
+		JCUser topicStarter = new JCUser();
+		JCUser otherUser = new JCUser();
+
+		Post post1 = new Post(topicStarter, "Post N1 by topic starter");
+		post1.setCreationDate(new DateTime());
+		Post post2 = new Post(otherUser, "Post N2 by other user");
+		post2.setCreationDate(new DateTime());
+
+		Topic topic = new Topic(topicStarter, "Topic title for testing");
+		topic.addPost(post1);
+		topic.addPost(post2);
+
+		return topic;
+	}
 }

--- a/jcommune-service/src/main/java/org/jtalks/jcommune/service/transactional/TransactionalTopicModificationService.java
+++ b/jcommune-service/src/main/java/org/jtalks/jcommune/service/transactional/TransactionalTopicModificationService.java
@@ -325,13 +325,11 @@ public class TransactionalTopicModificationService implements TopicModificationS
      * {@inheritDoc}
      */
     @PreAuthorize("(hasPermission(#topic.branch.id, 'BRANCH', 'BranchPermission.DELETE_OWN_POSTS') and " +
-            "#topic.topicStarter.username == principal.username and " +
-            "#topic.postCount == 1) or " +
+            "#topic.containsOwnerPostsOnly) or " +
             "(hasPermission(#topic.branch.id, 'BRANCH', 'BranchPermission.DELETE_OTHERS_POSTS') and " +
             "hasPermission(#topic.branch.id, 'BRANCH', 'BranchPermission.DELETE_OWN_POSTS'))")
     @Override
     public void deleteTopic(Topic topic) throws NotFoundException {
-
         Collection<JCUser> subscribers = subscriptionService.getAllowedSubscribers(topic);
 
         Branch branch = deleteTopicSilent(topic);

--- a/jcommune-view/jcommune-web-view/src/main/webapp/WEB-INF/jsp/topic/postList.jsp
+++ b/jcommune-view/jcommune-web-view/src/main/webapp/WEB-INF/jsp/topic/postList.jsp
@@ -212,7 +212,7 @@
                 <jtalks:hasPermission targetId="${topic.branch.id}" targetType="BRANCH"
                                       permission="BranchPermission.DELETE_OWN_POSTS">
                   <c:set var="isDeleteButtonAvailable"
-                         value='${userId == post.userCreated.id && postsPage.numberOfElements == 1}'/>
+						 value='${topic.containsOwnerPostsOnly}'/>
                   <jtalks:hasPermission targetId='${topic.branch.id}' targetType='BRANCH'
                                         permission='BranchPermission.DELETE_OTHERS_POSTS'>
                     <c:set var="isDeleteButtonAvailable" value="true"/>


### PR DESCRIPTION
- User can delete own starting post if no other user has added a reply, or those replies were removed/deleted by their owners
- "Delete" button is also visible when there are several posts added only by initial topic starter