### PR TITLE
JC-2189 The name of current branch disappears in breadcrumbs after validation during creating new topic

### DIFF
--- a/jcommune-plugins/questions-n-answers-plugin/src/main/java/org/jtalks/jcommune/plugin/questionsandanswers/controller/QuestionsAndAnswersController.java
+++ b/jcommune-plugins/questions-n-answers-plugin/src/main/java/org/jtalks/jcommune/plugin/questionsandanswers/controller/QuestionsAndAnswersController.java
@@ -148,7 +148,7 @@ public class QuestionsAndAnswersController implements ApplicationContextAware, P
         Map<String, Object> data = getDefaultModel(request);
         topicDto.getTopic().setBranch(branch);
         if (result.hasErrors()) {
-            data.put(BREADCRUMB_LIST, breadcrumbBuilder.getNewTopicBreadcrumb(branch));
+            data.put(BREADCRUMB_LIST, breadcrumbBuilder.getForumBreadcrumb(branch));
             data.put(TOPIC_DTO, topicDto);
             data.put(RESULT, result);
             model.addAttribute(CONTENT, getMergedTemplate(engine, QUESTION_FORM_TEMPLATE_PATH, "UTF-8", data));

--- a/jcommune-plugins/questions-n-answers-plugin/src/main/java/org/jtalks/jcommune/plugin/questionsandanswers/controller/QuestionsAndAnswersController.java
+++ b/jcommune-plugins/questions-n-answers-plugin/src/main/java/org/jtalks/jcommune/plugin/questionsandanswers/controller/QuestionsAndAnswersController.java
@@ -148,7 +148,7 @@ public class QuestionsAndAnswersController implements ApplicationContextAware, P
         Map<String, Object> data = getDefaultModel(request);
         topicDto.getTopic().setBranch(branch);
         if (result.hasErrors()) {
-            data.put(BREADCRUMB_LIST, breadcrumbBuilder.getForumBreadcrumb(branch));
+            data.put(BREADCRUMB_LIST, breadcrumbBuilder.getNewTopicBreadcrumb(branch));
             data.put(TOPIC_DTO, topicDto);
             data.put(RESULT, result);
             model.addAttribute(CONTENT, getMergedTemplate(engine, QUESTION_FORM_TEMPLATE_PATH, "UTF-8", data));

--- a/jcommune-view/jcommune-web-controller/src/main/java/org/jtalks/jcommune/web/controller/CodeReviewController.java
+++ b/jcommune-view/jcommune-web-controller/src/main/java/org/jtalks/jcommune/web/controller/CodeReviewController.java
@@ -114,7 +114,7 @@ public class CodeReviewController {
                     .addObject(TOPIC_DTO, topicDto)
                     .addObject(BRANCH_ID, branchId)
                     .addObject(SUBMIT_URL, "/reviews/new?branchId=" + branchId)
-                    .addObject(BREADCRUMB_LIST, breadcrumbBuilder.getForumBreadcrumb(branch));
+                    .addObject(BREADCRUMB_LIST, breadcrumbBuilder.getNewTopicBreadcrumb(branch));
         }
         Topic topic = topicDto.getTopic();
         topic.setBranch(branch);

--- a/jcommune-view/jcommune-web-controller/src/main/java/org/jtalks/jcommune/web/controller/CodeReviewController.java
+++ b/jcommune-view/jcommune-web-controller/src/main/java/org/jtalks/jcommune/web/controller/CodeReviewController.java
@@ -114,7 +114,7 @@ public class CodeReviewController {
                     .addObject(TOPIC_DTO, topicDto)
                     .addObject(BRANCH_ID, branchId)
                     .addObject(SUBMIT_URL, "/reviews/new?branchId=" + branchId)
-                    .addObject(BREADCRUMB_LIST, breadcrumbBuilder.getNewTopicBreadcrumb(branch));
+                    .addObject(BREADCRUMB_LIST, breadcrumbBuilder.getForumBreadcrumb(branch));
         }
         Topic topic = topicDto.getTopic();
         topic.setBranch(branch);

--- a/jcommune-view/jcommune-web-controller/src/main/java/org/jtalks/jcommune/web/controller/TopicController.java
+++ b/jcommune-view/jcommune-web-controller/src/main/java/org/jtalks/jcommune/web/controller/TopicController.java
@@ -171,7 +171,7 @@ public class TopicController {
                     .addObject(BRANCH_ID, branchId)
                     .addObject(TOPIC_DTO, topicDto)
                     .addObject(SUBMIT_URL, "/topics/new?branchId=" + branchId)
-                    .addObject(BREADCRUMB_LIST, breadcrumbBuilder.getForumBreadcrumb(branch));
+                    .addObject(BREADCRUMB_LIST, breadcrumbBuilder.getNewTopicBreadcrumb(branch));
         }
         Topic topic = topicDto.getTopic();
         topic.setBranch(branch);

--- a/jcommune-view/jcommune-web-controller/src/test/java/org/jtalks/jcommune/web/controller/TopicControllerTest.java
+++ b/jcommune-view/jcommune-web-controller/src/test/java/org/jtalks/jcommune/web/controller/TopicControllerTest.java
@@ -205,7 +205,7 @@ public class TopicControllerTest {
         ModelAndView mav = controller.createTopic(getDto(), result, BRANCH_ID);
 
         verify(branchService).get(BRANCH_ID);
-        verify(breadcrumbBuilder).getForumBreadcrumb(branch);
+        verify(breadcrumbBuilder).getNewTopicBreadcrumb(branch);
         //
         assertViewName(mav, "topic/topicForm");
         long branchId = assertAndReturnModelAttributeOfType(mav, "branchId", Long.class);


### PR DESCRIPTION
Fix for CR and Q&A topic`s breadcrumbs 