### PR TITLE
JC-1269 Available delete button for user without rights fix

### DIFF
--- a/jcommune-service/src/main/java/org/jtalks/jcommune/service/transactional/TransactionalTopicModificationService.java
+++ b/jcommune-service/src/main/java/org/jtalks/jcommune/service/transactional/TransactionalTopicModificationService.java
@@ -325,7 +325,7 @@ public class TransactionalTopicModificationService implements TopicModificationS
      * {@inheritDoc}
      */
     @PreAuthorize("(hasPermission(#topic.branch.id, 'BRANCH', 'BranchPermission.DELETE_OWN_POSTS') and " +
-            "#topic.containsOwnerPostsOnly) or " +
+            "#topic.containsOwnerPostsOnly and #topic.topicStarter.id == principal.id)  or " +
             "(hasPermission(#topic.branch.id, 'BRANCH', 'BranchPermission.DELETE_OTHERS_POSTS') and " +
             "hasPermission(#topic.branch.id, 'BRANCH', 'BranchPermission.DELETE_OWN_POSTS'))")
     @Override

--- a/jcommune-view/jcommune-web-view/src/main/webapp/WEB-INF/jsp/topic/postList.jsp
+++ b/jcommune-view/jcommune-web-view/src/main/webapp/WEB-INF/jsp/topic/postList.jsp
@@ -209,14 +209,16 @@
             <c:choose>
               <%--Controls for the first post, they affect topic--%>
               <c:when test="${isFirstPost}">
-                <jtalks:hasPermission targetId="${topic.branch.id}" targetType="BRANCH"
-                                      permission="BranchPermission.DELETE_OWN_POSTS">
-                  <c:set var="isDeleteButtonAvailable"
-						 value='${topic.containsOwnerPostsOnly}'/>
+                  <c:if test='${userId == topic.topicStarter.id}'>
+                      <jtalks:hasPermission targetId="${topic.branch.id}" targetType="BRANCH"
+                                    permission="BranchPermission.DELETE_OWN_POSTS">
+                          <c:set var="isDeleteButtonAvailable"
+				              value='${topic.containsOwnerPostsOnly}'/>
+				      </jtalks:hasPermission>
+			      </c:if>
                   <jtalks:hasPermission targetId='${topic.branch.id}' targetType='BRANCH'
                                         permission='BranchPermission.DELETE_OTHERS_POSTS'>
                     <c:set var="isDeleteButtonAvailable" value="true"/>
-                  </jtalks:hasPermission>
                 </jtalks:hasPermission>
               </c:when>
               <%--Controls for the any other ordinaru post--%>


### PR DESCRIPTION
For making delete button available on the first post there was
check that logined user has rights to delete his own posts. Also,there
was check that there are only posts of the author of the first post.
But there was not verification that currently logined user is actually
the author of this post. I've added this check.