### PR TITLE
JC-1501 Fix of the issue with links to users with '%'  in usernames

### DIFF
--- a/jcommune-service/src/test/java/org/jtalks/jcommune/service/nontransactional/MentionedUsersTest.java
+++ b/jcommune-service/src/test/java/org/jtalks/jcommune/service/nontransactional/MentionedUsersTest.java
@@ -34,8 +34,7 @@ import static java.lang.String.format;
 import static java.util.Arrays.asList;
 import static org.mockito.Mockito.*;
 import static org.mockito.MockitoAnnotations.initMocks;
-import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.*;
 
 /** @author Anuar_Nurmakanov */
 public class MentionedUsersTest {
@@ -146,8 +145,8 @@ public class MentionedUsersTest {
         MentionedUsers mentionedUsers = MentionedUsers.parse(textWithUsersMentioning);
         Set<String> extractedUserNames = mentionedUsers.extractAllMentionedUsers(textWithUsersMentioning);
 
-        assertTrue(extractedUserNames.contains("иванов"), "иванов is mentioned, so he should be extracted.");
-        assertTrue(extractedUserNames.contains("\\yak"), "\\yak is mentioned, so he should be extracted.");
+        assertFalse(extractedUserNames.contains("иванов"), "We don't have to decode this values.");
+        assertFalse(extractedUserNames.contains("\\yak"), "We don't have to decode this value.");
     }
 
     @Test
@@ -416,13 +415,13 @@ public class MentionedUsersTest {
 
         MentionedUsers mentionedUsers = MentionedUsers.parse(notProcessedSource);
 
-        String expectedAfterProcess = format(MENTIONING_WITH_LINK_TO_PROFILE_TEMPALTE,
+        String wrongAfterProcess = format(MENTIONING_WITH_LINK_TO_PROFILE_TEMPALTE,
                 cyrillicCharsUserProfile, cyrillicCharsUserName,
                 cyrillicCharsUserWithSpaceProfile, cyrillicCharsUserNameWithSpaces);
 
         String actualAfterProcess = mentionedUsers.getTextWithProcessedUserTags(userDao);
 
-        assertEquals(actualAfterProcess, expectedAfterProcess);
+        assertFalse(actualAfterProcess.equals(wrongAfterProcess), "Values which seems to be encoded should not be decoded.");
     }
 
     @Test

--- a/jcommune-view/jcommune-web-controller/src/main/java/org/jtalks/jcommune/web/controller/PostController.java
+++ b/jcommune-view/jcommune-web-controller/src/main/java/org/jtalks/jcommune/web/controller/PostController.java
@@ -66,7 +66,7 @@ public class PostController {
     public static final String POST_DTO = "postDto";
     public static final String TOPIC_TITLE = "topicTitle";
     public static final String BREADCRUMB_LIST = "breadcrumbList";
-    private static final Logger LOGGER = LoggerFactory.getLogger(UserController.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(PostController.class);
 
     private PostService postService;
     private LastReadPostService lastReadPostService;

--- a/jcommune-view/jcommune-web-view/src/main/webapp/resources/javascript/lib/wysiwyg-bbcode/editor.js
+++ b/jcommune-view/jcommune-web-view/src/main/webapp/resources/javascript/lib/wysiwyg-bbcode/editor.js
@@ -113,15 +113,7 @@ var lowerThenPlaceholder = "gertfgertgf@@@@@#4324234";
 function bbcode2html(allowedUrls) {
     elId = "#" + html_content_id;
     var textdata = " " + textboxelement.value;
-    textdata = textdata.replace(/%5D/gi, closeBracketCodePlaceholder);
-    textdata = textdata.replace(/%5B/gi, openBracketCodePlaceholder);
-    textdata = textdata.replace(/%22/gi, slashCodePlaceholder);
-    textdata = textdata.replace(/</gi, lowerThenPlaceholder);
     textdata = encodeURI(textdata);
-    textdata = textdata.replace(/%5D/gi, "]");
-    textdata = textdata.replace(/%5B/gi, "[");
-    textdata = textdata.replace(/%22/gi, "\"");
-    textdata = textdata.replace(/%20/gi, " ");
     previewUrl = allowedUrls[0];
     var segment = $.url($(elId).closest("form").attr("action")).segment();
     for(var a=0; a<segment.length; a++) {


### PR DESCRIPTION

The problem arose because of two reasons: on the submit of post phase
there were decoding of the username which was not previously encoded.
It was solved by simply removing of that decoding in the
MentionedUsers.java. Also this fix demanded some changes in the
MentionedUsersTest.java. The problem on the preview phase arose because
of replacement of some special symbols. I assume that simple encoding is
enough and that's why I removed this replacement.