### PR TITLE
JC-2212 No tooltip on 'Add syntax highlight' button

### DIFF
--- a/jcommune-plugin-api/src/main/resources/org/jtalks/jcommune/jcommune-plugin-api/web/templates/bbeditor.vm
+++ b/jcommune-plugin-api/src/main/resources/org/jtalks/jcommune/jcommune-plugin-api/web/templates/bbeditor.vm
@@ -101,7 +101,8 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
         <i class="icon-link"></i>
       </a>
 
-      <a class="btn dropdown-toggle" data-toggle="dropdown" href="#fake">
+      <a class="btn dropdown-toggle" data-toggle="dropdown" href="#fake"
+              title="<jcommune:message>label.answer.font_code</jcommune:message>">
         <jcommune:message>label.answer.font_code</jcommune:message>
         <span class="caret"></span>
       </a>

--- a/jcommune-view/jcommune-web-view/src/main/webapp/WEB-INF/tags/bbeditor.tag
+++ b/jcommune-view/jcommune-web-view/src/main/webapp/WEB-INF/tags/bbeditor.tag
@@ -105,7 +105,8 @@
       <i class="icon-link"></i>
     </a>
 
-    <a class="btn dropdown-toggle" data-toggle="dropdown" href="#fake">
+    <a class="btn dropdown-toggle" data-toggle="dropdown" href="#fake"
+       title="<spring:message code='label.answer.font_code'/>">
       <spring:message code="label.answer.font_code"/>
       <span class="caret"></span>
     </a>


### PR DESCRIPTION
Has been added tooltip message to the button 'Add syntax highlight'.