### PR TITLE
JC-1739 Fix of issue with repeated post request after refresh

### DIFF
--- a/jcommune-view/jcommune-web-controller/src/main/java/org/jtalks/jcommune/web/controller/PostController.java
+++ b/jcommune-view/jcommune-web-controller/src/main/java/org/jtalks/jcommune/web/controller/PostController.java
@@ -243,6 +243,19 @@ public class PostController {
         return new ModelAndView(this.redirectToPageWithPost(newbie.getId()));
     }
 
+    /**
+     * Gets validation errors from 'create' methods to redirect them to the view. We need it
+     * to implement POST/redirect/GET pattern, which leads to preventing of repeating POST request
+     * on browser refresh.
+     *
+     * @param page  page of the current post
+     * @param topicId ID of a topic
+     * @param postDto Dto with failed validation
+     * @param result  validation result
+     *
+     * @return {@code ModelAndView} object which shows form with an error message
+     * @throws NotFoundException when topic, branch or post not found
+     */
     @RequestMapping(method = RequestMethod.GET, value = "/topics/error/{topicId}")
     public ModelAndView errorRedirect(@RequestParam(value = "page", required = false) String page,
                                       @PathVariable(TOPIC_ID) Long topicId, @ModelAttribute @Valid PostDto postDto,

--- a/jcommune-view/jcommune-web-controller/src/test/java/org/jtalks/jcommune/web/controller/PostControllerTest.java
+++ b/jcommune-view/jcommune-web-controller/src/test/java/org/jtalks/jcommune/web/controller/PostControllerTest.java
@@ -35,6 +35,7 @@ import org.springframework.validation.BeanPropertyBindingResult;
 import org.springframework.validation.BindingResult;
 import org.springframework.web.bind.WebDataBinder;
 import org.springframework.web.servlet.ModelAndView;
+import org.springframework.web.servlet.mvc.support.RedirectAttributesModelMap;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
@@ -208,7 +209,7 @@ public class PostControllerTest {
         when(topicModificationService.replyToTopic(anyLong(), Matchers.<String>any(), eq(BRANCH_ID))).thenReturn(post);
         when(postService.calculatePageForPost(post)).thenReturn(1);
         //invoke the object under test
-        ModelAndView mav = controller.create(null, TOPIC_ID, getDto(), resultWithoutErrors);
+        ModelAndView mav = controller.create(null, TOPIC_ID, getDto(), resultWithoutErrors, null);
 
         //check expectations
         verify(topicModificationService).replyToTopic(TOPIC_ID, POST_CONTENT, BRANCH_ID);
@@ -223,13 +224,13 @@ public class PostControllerTest {
         BeanPropertyBindingResult resultWithErrors = mock(BeanPropertyBindingResult.class);
         when(resultWithErrors.hasErrors()).thenReturn(true);
         //invoke the object under test
-        ModelAndView mav = controller.create(null, TOPIC_ID, getDto(), resultWithErrors);
+        ModelAndView mav = controller.create(null, TOPIC_ID, getDto(), resultWithErrors, new RedirectAttributesModelMap());
 
         //check expectations
         verify(topicModificationService, never()).replyToTopic(anyLong(), anyString(), eq(BRANCH_ID));
 
         //check result
-        assertViewName(mav, "topic/postList");
+        assertEquals(mav.getViewName(), "redirect:/topics/error/" + TOPIC_ID + "?page=null");
     }
 
     @Test


### PR DESCRIPTION
There was changed error handling behavior. Now, instead of redirecting
to view it redirects to an error handling controller method. Thus, when
user refreshes page only GET request is repeated. In consequence, it
allows saving drafts and prevents unexpected text body errors.