### PR TITLE
Poulpe-528 Issue with 'User #0 not found' error

### DIFF
--- a/jcommune-model/src/main/java/org/jtalks/jcommune/model/entity/ObjectsFactory.java
+++ b/jcommune-model/src/main/java/org/jtalks/jcommune/model/entity/ObjectsFactory.java
@@ -15,8 +15,11 @@
 package org.jtalks.jcommune.model.entity;
 
 import org.apache.commons.lang.math.RandomUtils;
+import org.joda.time.DateTime;
 import org.jtalks.common.model.entity.*;
 
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -48,6 +51,36 @@ public final class ObjectsFactory {
         newUser.setFirstName("first name");
         newUser.setLastName("last name");
         return newUser;
+    }
+
+    public static JCUser getUserWithAllFieldsFilled() throws NoSuchMethodException, InvocationTargetException,
+            IllegalAccessException {
+        JCUser user = getDefaultUser();
+        DateTime dateTime = new DateTime();
+        user.setId(1);
+        user.setLanguage(Language.RUSSIAN);
+        user.setPageSize(1);
+        user.setLocation("location");
+        user.setSignature("signature");
+        user.setRegistrationDate(dateTime);
+        user.setEnabled(true);
+        user.setAutosubscribe(true);
+        user.setMentioningNotificationsEnabled(true);
+        user.setSendPmNotification(true);
+        user.getContacts().add(ObjectsFactory.getDefaultUserContact());
+        user.setAvatarLastModificationTime(dateTime);
+        user.setAllForumMarkedAsReadTime(dateTime);
+        user.setAvatar(new byte[]{1});
+        user.setVersion(1L);
+        user.setBanReason("Ban Reason");
+        user.setRole("Role");
+        Method setLastLogin = User.class.getDeclaredMethod("setLastLogin", DateTime.class);
+        Method setEncodedUsername = User.class.getDeclaredMethod("setEncodedUsername", String.class);
+        setLastLogin.setAccessible(true);
+        setEncodedUsername.setAccessible(true);
+        setLastLogin.invoke(user, new DateTime());
+        setEncodedUsername.invoke(user, "Encoded Username");
+        return user;
     }
 
     public static Branch getDefaultBranch() {

--- a/jcommune-model/src/test/java/org/jtalks/jcommune/model/entity/JCUserTest.java
+++ b/jcommune-model/src/test/java/org/jtalks/jcommune/model/entity/JCUserTest.java
@@ -20,8 +20,10 @@ import org.jtalks.common.model.entity.Group;
 import org.jtalks.common.model.entity.User;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.GrantedAuthorityImpl;
+import org.springframework.util.SerializationUtils;
 import org.testng.annotations.Test;
 
+import java.lang.reflect.InvocationTargetException;
 import java.util.Arrays;
 import java.util.List;
 
@@ -217,6 +219,27 @@ public class JCUserTest {
         assertEquals(language, Language.ENGLISH);
     }
 
+    @Test
+    public void entityFieldsShouldBeSerialized() throws NoSuchMethodException, InvocationTargetException,
+            IllegalAccessException {
+        JCUser user = ObjectsFactory.getUserWithAllFieldsFilled();
 
+        byte[] serialize = SerializationUtils.serialize(user);
+        JCUser serializedUser = (JCUser)SerializationUtils.deserialize(serialize);
+        assertReflectionEquals(user, serializedUser);
+    }
+
+    @Test
+    public void groupsFieldIsNotSerializable(){
+        List<Group> groups = Group.createGroupsWithNames("Group");
+        JCUser userInGroup = new JCUser("user","email","password");
+        userInGroup.setGroups(groups);
+
+        byte[] serialize = SerializationUtils.serialize(userInGroup);
+        JCUser serializedUser = (JCUser) SerializationUtils.deserialize(serialize);
+
+        assertNull(serializedUser.getGroups(),
+                "After deserialiation, the transient field `List<Group> groups` must be null");
+    }
 
 }


### PR DESCRIPTION
We have to customize serialization of the entity JCUser because of we used to loose 'id' and 'uuid' data from org.jtalks.common.model.entity.Entity class when saved other User details in session-storage-file.
The fix is similar to issue of PoulpeUser serialization (http://jira.jtalks.org/browse/POULPE-528)

Created:
  - methods writeObject(), readObject() and serialVersionUID field.
  - test method for checking is most fields of User entity serialized
  - test method to assert the field `List<Group> groups` can't be serialized with rest of the JCUser fields.

Implemented additional ObjectFactory method to reduce size of code in test method.