### PR TITLE
JC-1739 Posted draft in Q/A topic doesn't remove

### DIFF
--- a/jcommune-view/jcommune-web-view/src/main/webapp/resources/javascript/app/postDraft.js
+++ b/jcommune-view/jcommune-web-view/src/main/webapp/resources/javascript/app/postDraft.js
@@ -169,6 +169,11 @@ $(document).ready(function() {
         postPressed = true;
     });
 
+    $(".submit-form").submit(function(e) {
+        //We need to abort save request in case if user posts message with hot-keys 'ctr+enter' to prevent race condition
+        postPressed = true;
+    });
+
     /**
      * Sends request for deletion draft
      */


### PR DESCRIPTION
Fix for issue with appearing draft in answer form after submitting with hot-keys 'ctr+enter' in Firefox