### PR TITLE
JC-2179_Users_Ligth_Bulb_deleted

### DIFF
--- a/jcommune-view/jcommune-web-view/src/main/webapp/WEB-INF/jsp/topic/postList.jsp
+++ b/jcommune-view/jcommune-web-view/src/main/webapp/WEB-INF/jsp/topic/postList.jsp
@@ -275,12 +275,6 @@
     <td class="userinfo">
       <div>
         <p>
-          <spring:message var="onlineTip" code="label.tips.user_online"/>
-          <spring:message var="offlineTip" code="label.tips.user_offline"/>
-          <c:set var="online" value='<i class="icon-online" title="${onlineTip}"></i>'/>
-          <c:set var="offline" value='<i class="icon-offline" title="${offlineTip}"></i>'/>
-          <jtalks:ifContains collection="${usersOnline}" object="${post.userCreated}"
-                             successMessage="${online}" failMessage="${offline}"/>
           <a class='post-userinfo-username'
              href="${pageContext.request.contextPath}/users/${post.userCreated.id}"
              title="<spring:message code='label.tips.view_profile'/>">

--- a/jcommune-view/jcommune-web-view/src/main/webapp/WEB-INF/jsp/topic/postList.jsp
+++ b/jcommune-view/jcommune-web-view/src/main/webapp/WEB-INF/jsp/topic/postList.jsp
@@ -275,6 +275,12 @@
     <td class="userinfo">
       <div>
         <p>
+          <spring:message var="onlineTip" code="label.tips.user_online"/>
+          <spring:message var="offlineTip" code="label.tips.user_offline"/>
+          <c:set var="online" value='<i class="icon-online" title="${onlineTip}"></i>'/>
+          <c:set var="offline" value='<i class="icon-offline" title="${offlineTip}"></i>'/>
+          <jtalks:ifContains collection="${usersOnline}" object="${post.userCreated}"
+                             successMessage="${online}" failMessage="${offline}"/>
           <a class='post-userinfo-username'
              href="${pageContext.request.contextPath}/users/${post.userCreated.id}"
              title="<spring:message code='label.tips.view_profile'/>">


### PR DESCRIPTION
Each user info block in Topic and CR posts has user's online status indicator - light bulb: It was decided that this indication is not important and should be removed.	Each user info block in Topic and CR posts has user's online status indicator - light bulb: http://jira.jtalks.org/secure/attachment/15518/Activity_light_bulb.png
 It was decided that this indication is not important and should be removed.