### PR TITLE
JC-2179 - User's online status indicator deleted

### DIFF
--- a/jcommune-view/jcommune-web-controller/src/main/java/org/jtalks/jcommune/web/controller/PostController.java
+++ b/jcommune-view/jcommune-web-controller/src/main/java/org/jtalks/jcommune/web/controller/PostController.java
@@ -32,7 +32,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.propertyeditors.StringTrimmerEditor;
 import org.springframework.data.domain.Page;
 import org.springframework.orm.hibernate3.HibernateOptimisticLockingFailureException;
-import org.springframework.security.core.session.SessionRegistry;
 import org.springframework.stereotype.Controller;
 import org.springframework.validation.BindingResult;
 import org.springframework.web.bind.WebDataBinder;
@@ -74,7 +73,6 @@ public class PostController {
     private BBCodeService bbCodeService;
     private UserService userService;
     private LocationService locationService;
-    private SessionRegistry sessionRegistry;
     private EntityToDtoConverter converter;
 
     /**
@@ -105,8 +103,7 @@ public class PostController {
     public PostController(PostService postService, BreadcrumbBuilder breadcrumbBuilder,
                           TopicFetchService topicFetchService, TopicModificationService topicModificationService,
                           BBCodeService bbCodeService, LastReadPostService lastReadPostService,
-                          UserService userService, LocationService locationService, SessionRegistry sessionRegistry,
-                          EntityToDtoConverter converter) {
+                          UserService userService, LocationService locationService, EntityToDtoConverter converter) {
         this.postService = postService;
         this.breadcrumbBuilder = breadcrumbBuilder;
         this.topicFetchService = topicFetchService;
@@ -115,7 +112,6 @@ public class PostController {
         this.lastReadPostService = lastReadPostService;
         this.userService = userService;
         this.locationService = locationService;
-        this.sessionRegistry = sessionRegistry;
         this.converter = converter;
     }
 
@@ -269,7 +265,6 @@ public class PostController {
 
         return new ModelAndView("topic/postList")
                 .addObject("viewList", locationService.getUsersViewing(topic))
-                .addObject("usersOnline", sessionRegistry.getAllPrincipals())
                 .addObject("postsPage", postsPage)
                 .addObject("topic", topic)
                 .addObject(POST_DTO, postDto)

--- a/jcommune-view/jcommune-web-controller/src/test/java/org/jtalks/jcommune/web/controller/PostControllerTest.java
+++ b/jcommune-view/jcommune-web-controller/src/test/java/org/jtalks/jcommune/web/controller/PostControllerTest.java
@@ -30,7 +30,6 @@ import org.mockito.ArgumentMatcher;
 import org.mockito.Matchers;
 import org.mockito.Mock;
 import org.springframework.beans.propertyeditors.StringTrimmerEditor;
-import org.springframework.security.core.session.SessionRegistry;
 import org.springframework.validation.BeanPropertyBindingResult;
 import org.springframework.validation.BindingResult;
 import org.springframework.web.bind.WebDataBinder;
@@ -77,8 +76,6 @@ public class PostControllerTest {
     @Mock
     private LocationService locationService;
     @Mock
-    private SessionRegistry sessionRegistry;
-    @Mock
     private EntityToDtoConverter converter;
     @Mock
     private HttpServletRequest request;
@@ -118,7 +115,7 @@ public class PostControllerTest {
 
         controller = new PostController(
                 postService, breadcrumbBuilder, topicFetchService, topicModificationService,
-                bbCodeService, lastReadPostService, userService, locationService, sessionRegistry, converter);
+                bbCodeService, lastReadPostService, userService, locationService, converter);
     }
 
     @Test

--- a/jcommune-view/jcommune-web-view/src/main/webapp/WEB-INF/jsp/topic/postList.jsp
+++ b/jcommune-view/jcommune-web-view/src/main/webapp/WEB-INF/jsp/topic/postList.jsp
@@ -275,12 +275,6 @@
     <td class="userinfo">
       <div>
         <p>
-          <spring:message var="onlineTip" code="label.tips.user_online"/>
-          <spring:message var="offlineTip" code="label.tips.user_offline"/>
-          <c:set var="online" value='<i class="icon-online" title="${onlineTip}"></i>'/>
-          <c:set var="offline" value='<i class="icon-offline" title="${offlineTip}"></i>'/>
-          <jtalks:ifContains collection="${usersOnline}" object="${post.userCreated}"
-                             successMessage="${online}" failMessage="${offline}"/>
           <a class='post-userinfo-username'
              href="${pageContext.request.contextPath}/users/${post.userCreated.id}"
              title="<spring:message code='label.tips.view_profile'/>">


### PR DESCRIPTION
Each user info block in Topic and CR posts has user's online status indicator - light bulb: http://jira.jtalks.org/secure/attachment/15518/Activity_light_bulb.png
It was decided that this indication is not important and should be removed.