### PR TITLE
JC-2094 Refresh captcha in Firefox.

### DIFF
--- a/jcommune-plugins/kaptcha-plugin/src/main/java/org/jtalks/jcommune/plugin/kaptcha/KaptchaPluginService.java
+++ b/jcommune-plugins/kaptcha-plugin/src/main/java/org/jtalks/jcommune/plugin/kaptcha/KaptchaPluginService.java
@@ -22,6 +22,7 @@ import com.google.code.kaptcha.util.Config;
 import com.google.common.collect.ImmutableMap;
 import org.apache.commons.lang.StringUtils;
 import org.apache.velocity.app.VelocityEngine;
+import org.apache.velocity.tools.generic.DateTool;
 import org.jtalks.jcommune.model.dto.UserDto;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.ui.velocity.VelocityEngineUtils;
@@ -52,6 +53,8 @@ public class KaptchaPluginService {
     private static final String BASE_URL = "baseUrl";
     private static final String FORM_ELEMENT_ID = "formElementId";
     private static final String PLUGIN_PREFIX = "plugin-";
+    private static final String DATE = "date";
+
     private Producer captchaProducer;
 
     public KaptchaPluginService(int width, int height, int length, String possibleSymbols) {
@@ -131,6 +134,7 @@ public class KaptchaPluginService {
         model.put(CAPTCHA_PLUGIN_ID, pluginId);
         model.put(FORM_ELEMENT_ID, getFormElementId(pluginId));
         model.put(BASE_URL, getDeploymentRootUrl(request));
+        model.put(DATE, new DateTool());
         return VelocityEngineUtils.mergeTemplateIntoString(
                 engine, "org/jtalks/jcommune/plugin/kaptcha/template/captcha.vm", "UTF-8", model);
     }

--- a/jcommune-plugins/kaptcha-plugin/src/main/resources/org/jtalks/jcommune/plugin/kaptcha/template/captcha.vm
+++ b/jcommune-plugins/kaptcha-plugin/src/main/resources/org/jtalks/jcommune/plugin/kaptcha/template/captcha.vm
@@ -16,7 +16,9 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 *#
 <div class='control-group'>
   <div class='controls captcha-images'>
-    <img class='captcha-img' alt='${altCaptcha}' src='${baseUrl}/plugin/${captchaPluginId}/refreshCaptcha'/>
+##  Fix for [http://jira.jtalks.org/browse/JC-2094] issue. Query t="date" added because Firefox ignores cache control
+##  headers if DOM changed by JavaScript and no way to prevent image caching.
+    <img class='captcha-img' alt='${altCaptcha}' src='${baseUrl}/plugin/${captchaPluginId}/refreshCaptcha?t=$date.getSystemTime()'/>
     <img class='captcha-refresh' alt='${altRefreshCaptcha}' src='${baseUrl}/resources/images/captcha-refresh.png'/>
   </div>
   <div class='controls'>


### PR DESCRIPTION
Fix for [http://jira.jtalks.org/browse/JC-2094] issue. Query t="date" added because Firefox ignores cache control headers if DOM changed by JavaScript and no way to prevent image caching.