### PR TITLE
JC-2086 Refresh captcha via TAB:

### DIFF
--- a/jcommune-plugins/kaptcha-plugin/src/main/resources/org/jtalks/jcommune/plugin/kaptcha/template/captcha.vm
+++ b/jcommune-plugins/kaptcha-plugin/src/main/resources/org/jtalks/jcommune/plugin/kaptcha/template/captcha.vm
@@ -19,7 +19,9 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 ##  Fix for [http://jira.jtalks.org/browse/JC-2094] issue. Query t="date" added because Firefox ignores cache control
 ##  headers if DOM changed by JavaScript and no way to prevent image caching.
     <img class='captcha-img' alt='${altCaptcha}' src='${baseUrl}/plugin/${captchaPluginId}/refreshCaptcha?t=$date.getSystemTime()'/>
-    <img class='captcha-refresh' alt='${altRefreshCaptcha}' src='${baseUrl}/resources/images/captcha-refresh.png'/>
+    <button class="btn btn-default" id="refreshCaptchaBtn">
+      <img class='captcha-refresh' alt='${altRefreshCaptcha}' src='${baseUrl}/resources/images/captcha-refresh.png'/>
+    </button>
   </div>
   <div class='controls'>
     <input type='text' id='${formElementId}' name='userDto.captchas[${formElementId}]'

--- a/jcommune-view/jcommune-web-view/src/main/webapp/resources/javascript/app/registration.js
+++ b/jcommune-view/jcommune-web-view/src/main/webapp/resources/javascript/app/registration.js
@@ -143,11 +143,11 @@ function signUp(e) {
                 footerContent: footerContent,
                 maxWidth: 400,
                 maxHeight: 600,
-                tabNavigation: ['#username', '#email', '#password', '#passwordConfirm', '.captcha',
+                tabNavigation: ['#username', '#email', '#password', '#passwordConfirm', '#refreshCaptchaBtn','.captcha',
                                 '#signup-submit-button', 'button.close'],
                 handlers: {
                     '#signup-submit-button': {'click': submitFunc},
-                    '.captcha-refresh, .captcha-img': {'click' : refreshCaptcha}
+                    '#refreshCaptchaBtn': {'click' : refreshCaptcha}
                 }
             });
         }
@@ -158,7 +158,8 @@ function signUp(e) {
 /**
  * Get new captcha images
  */
-function refreshCaptcha() {
+function refreshCaptcha(e) {
+    e.preventDefault();
     jDialog.dialog.find('.captcha-img').each(function(){
         var attrSrc = $(this).attr("src").split("?")[0] + "?param=" + $.now();
         $(this).removeAttr('src');


### PR DESCRIPTION
- refresh img wrapped with < button >, since can't focus img.
- Added #refreshCaptchaBtn id to tabNavigation list.
- changed refreshCaptcha function because click event caused POST request to nonexistent resource.