### PR TITLE
JC-2086 Refresh captcha via TAB [REWORKED]:

### DIFF
--- a/jcommune-plugins/kaptcha-plugin/src/main/resources/org/jtalks/jcommune/plugin/kaptcha/template/captcha.vm
+++ b/jcommune-plugins/kaptcha-plugin/src/main/resources/org/jtalks/jcommune/plugin/kaptcha/template/captcha.vm
@@ -19,9 +19,10 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 ##  Fix for [http://jira.jtalks.org/browse/JC-2094] issue. Query t="date" added because Firefox ignores cache control
 ##  headers if DOM changed by JavaScript and no way to prevent image caching.
     <img class='captcha-img' alt='${altCaptcha}' src='${baseUrl}/plugin/${captchaPluginId}/refreshCaptcha?t=$date.getSystemTime()'/>
-    <button class="btn btn-default" id="refreshCaptchaBtn">
+##    Div can't recieve focus without tabindex attribute.
+    <div class="btn btn-default btn-captcha-refresh" tabindex="0">
       <img class='captcha-refresh' alt='${altRefreshCaptcha}' src='${baseUrl}/resources/images/captcha-refresh.png'/>
-    </button>
+    </div>
   </div>
   <div class='controls'>
     <input type='text' id='${formElementId}' name='userDto.captchas[${formElementId}]'

--- a/jcommune-plugins/kaptcha-plugin/src/test/java/org/jtalks/jcommune/plugin/kaptcha/KaptchaPluginServiceTest.java
+++ b/jcommune-plugins/kaptcha-plugin/src/test/java/org/jtalks/jcommune/plugin/kaptcha/KaptchaPluginServiceTest.java
@@ -119,7 +119,7 @@ public class KaptchaPluginServiceTest {
         String actual = service.getHtml(request, "1", Locale.ENGLISH);
 
         assertTrue(actual.contains("<img class='captcha-img' "
-                + "alt='Captcha' src='http://localhost/plugin/1/refreshCaptcha'/>"));
+                + "alt='Captcha' src='http://localhost/plugin/1/refreshCaptcha?t="));
         assertTrue(actual.contains("<img class='captcha-refresh' alt='Refresh captcha' "
                 + "src='http://localhost/resources/images/captcha-refresh.png'/>"));
         assertTrue(actual.contains("<input type='text' id='plugin-1' name='userDto.captchas[plugin-1]'"));

--- a/jcommune-view/jcommune-web-view/src/main/webapp/resources/css/app/application.css
+++ b/jcommune-view/jcommune-web-view/src/main/webapp/resources/css/app/application.css
@@ -490,6 +490,12 @@ div.anchor {
     vertical-align: middle;
 }
 
+#signup-modal-dialog .btn-captcha-refresh {
+    background: none;
+    border: none;
+    box-shadow: none;
+}
+
 div.signup {
     margin-top: 10px;
     margin-left: 25px;

--- a/jcommune-view/jcommune-web-view/src/main/webapp/resources/javascript/app/registration.js
+++ b/jcommune-view/jcommune-web-view/src/main/webapp/resources/javascript/app/registration.js
@@ -143,11 +143,11 @@ function signUp(e) {
                 footerContent: footerContent,
                 maxWidth: 400,
                 maxHeight: 600,
-                tabNavigation: ['#username', '#email', '#password', '#passwordConfirm', '#refreshCaptchaBtn','.captcha',
-                                '#signup-submit-button', 'button.close'],
+                tabNavigation: ['#username', '#email', '#password', '#passwordConfirm', '.btn-captcha-refresh',
+                                '.captcha', '#signup-submit-button', 'button.close'],
                 handlers: {
                     '#signup-submit-button': {'click': submitFunc},
-                    '#refreshCaptchaBtn': {'click' : refreshCaptcha}
+                    '.btn-captcha-refresh, .captcha-img': {'click' : refreshCaptcha, 'keydown': refreshCaptchaKeyHandler}
                 }
             });
         }
@@ -158,8 +158,7 @@ function signUp(e) {
 /**
  * Get new captcha images
  */
-function refreshCaptcha(e) {
-    e.preventDefault();
+function refreshCaptcha() {
     jDialog.dialog.find('.captcha-img').each(function(){
         var attrSrc = $(this).attr("src").split("?")[0] + "?param=" + $.now();
         $(this).removeAttr('src');
@@ -175,6 +174,12 @@ function refreshCaptchaJsp() {
         $(this).attr('src', attrSrc);
     });
     $('#form').find('.captcha').val('');
+}
+
+function refreshCaptchaKeyHandler(e) {
+    if (e.keyCode && e.keyCode === enterCode) {
+        refreshCaptcha();
+    }
 }
 
 /**


### PR DESCRIPTION
- refresh img wrapped with < div >, since img tag can't be in focus .
- added style 'btn-captcha-refresh' which overrides bootstrap button style.
- added  class '.btn-captcha-refresh'  to tabNavigation list.
- added separated keyboard handler to update captcha through keyboard.
- restored button style and sign up form behaviour.