### PR TITLE
JC-2126 On Sign In popup window cursor is not focused on link

### DIFF
--- a/jcommune-view/jcommune-web-view/src/main/webapp/resources/javascript/app/signin.js
+++ b/jcommune-view/jcommune-web-view/src/main/webapp/resources/javascript/app/signin.js
@@ -65,8 +65,8 @@ $(function () {
             bodyContent: bodyContent,
             footerContent: footerContent,
             maxWidth: 350,
-            tabNavigation: ['#userName', '#password', '#rememberme-area input', '#restore-passwd a',
-                '#signin-submit-button'],
+            tabNavigation: ['#userName', '#password', '#rememberme-area input', '#dialog-signup-link', '#restore-passwd a',
+                '#signin-submit-button', 'button.close'],
             handlers: {
                 '#signin-modal-dialog': {'submit': sendLoginPost},
                 '#dialog-signup-link': {'click': function(e){


### PR DESCRIPTION
- fixed tabNavigation property of the Sign-In dialogue.

P/S: note at the bottom of this issue: "cursor is not focused on “Save” button when moving via Tab key" is not confirmed, because I have the focus on Save button via Tab (in browsers Opera 12.17, Crome 45.0.2454.101 m).