### PR TITLE
JC-1998 Wrong error message below the "New Password" field

### DIFF
--- a/jcommune-view/jcommune-web-controller/src/main/java/org/jtalks/jcommune/web/dto/UserSecurityDto.java
+++ b/jcommune-view/jcommune-web-controller/src/main/java/org/jtalks/jcommune/web/dto/UserSecurityDto.java
@@ -36,7 +36,8 @@ public class UserSecurityDto {
     private long userId;
 
     private String currentUserPassword;
-    @Size(min = User.PASSWORD_MIN_LENGTH, max = User.PASSWORD_MAX_LENGTH)
+    @Size(min = User.PASSWORD_MIN_LENGTH, max = User.PASSWORD_MAX_LENGTH,
+            message = "{user.password.length_constraint_violation}")
     private String newUserPassword;
     private String newUserPasswordConfirm;
 


### PR DESCRIPTION
- added a message attribute of the annotation Size (the newUserPassword
  field of the UserSecurityDto class)