### PR TITLE
JC-2092 There is no confirmation popup when leaving pages with unsaved data

### DIFF
--- a/jcommune-view/jcommune-web-view/src/main/webapp/resources/javascript/app/leaveConfirm.js
+++ b/jcommune-view/jcommune-web-view/src/main/webapp/resources/javascript/app/leaveConfirm.js
@@ -36,8 +36,11 @@ $(document).ready(function () {
         if (currentData != newData) return '';
     });
 
-    $(document).on('click', allowed_transitions, function (event) {
-        $(window).off('beforeunload');
+    $.each(allowed_transitions, function(element) {
+        $(element).click(function(event){
+            $(window).off('beforeunload');
+            event.stopPropagation()
+        });
     });
     
     $(document).on('submit', allowed_transitions, function (event) {


### PR DESCRIPTION
- banned the forwarding of the "click" event upwards to parent elements.

P/S: according to the jquery documentation, any event which occurs on a child element propagate up the hierarchy. So when you click on any element occurs unsubscribing from the events of "beforeunload". To prevent this, you should use "event.stopPropagation()". But there's a catch - this method does not work if the subscription to the event (for example "click") occurs within the method "$('element').on()". Because of this I had to use a loop "$.each()" to the array elements.

