### PR TITLE
JC-2198 Rename "Save" Button on Topic and CR creation page

### DIFF
--- a/jcommune-view/jcommune-web-view/src/main/webapp/WEB-INF/jsp/registration.jsp
+++ b/jcommune-view/jcommune-web-view/src/main/webapp/WEB-INF/jsp/registration.jsp
@@ -32,7 +32,7 @@
 
 <div class="container form-login-related registration-page">
   <form:form id="form" name="form" action='${pageContext.request.contextPath}/user/new'
-             modelAttribute="newUser" method="POST" class='form-vertical'>
+             modelAttribute="newUser" method="POST" class='form-vertical' tabindex="-1">
     <fieldset>
       <legend><spring:message code="label.fillmessage"/></legend>
       <div class="control-group">

--- a/jcommune-view/jcommune-web-view/src/main/webapp/resources/javascript/app/registration.js
+++ b/jcommune-view/jcommune-web-view/src/main/webapp/resources/javascript/app/registration.js
@@ -33,7 +33,6 @@ $(function () {
         captchaContainer.find('.captcha-img, .btn-captcha-refresh').on({
             click: refreshCaptchaJsp,
             keypress: function(e) {
-                e.preventDefault();
                 if (isEnterKeyPressed(e)) {
                     refreshCaptchaJsp();
                 }


### PR DESCRIPTION
- All initial buttons to create topics should be: Send
- All editing buttons (both for post and topic) should be: Edit
- All the buttons to save corrections should be: Save
- Buttons to initially create post should stay unchanged