### PR TITLE
JC-2198 Rename "Save" Button on Topic and CR creation page

### DIFF
--- a/jcommune-view/jcommune-web-view/src/main/webapp/WEB-INF/jsp/codeReviewForm.jsp
+++ b/jcommune-view/jcommune-web-view/src/main/webapp/WEB-INF/jsp/codeReviewForm.jsp
@@ -56,7 +56,7 @@
     </div>
 
     <input id="post" type="submit" class="btn btn-primary" accesskey="s" name="post" tabindex="300"
-           value="<spring:message code="label.save"/>"/>
+           value="<spring:message code="label.send"/>"/>
   </form:form>
 
   <a href="${pageContext.request.contextPath}/branches/${branchId}" tabindex="1000" class='back-btn'>

--- a/jcommune-view/jcommune-web-view/src/main/webapp/WEB-INF/jsp/topic/topicForm.jsp
+++ b/jcommune-view/jcommune-web-view/src/main/webapp/WEB-INF/jsp/topic/topicForm.jsp
@@ -74,7 +74,7 @@
         <form:errors path="topic.announcement"/>
       </div>
     </jtalks:hasPermission>
-    <jtalks:bbeditor labelForAction="label.save"
+    <jtalks:bbeditor labelForAction="${pollEditing ? 'label.save' : 'label.send'}"
                      postText="${topicDto.bodyText}"
                      bodyParameterName="bodyText"
                      back="${pageContext.request.contextPath}/branches/${branchId}"/>


### PR DESCRIPTION
- All initial buttons to create topics should be: Send
- All editing buttons (both for post and topic) should be: Edit
- All the buttons to save corrections should be: Save
- Buttons to initially create post should stay unchanged