### PR TITLE
JC-2115 Captcha text field has different length on pop-up window and on registration page

### DIFF
--- a/jcommune-plugins/kaptcha-plugin/src/main/resources/org/jtalks/jcommune/plugin/kaptcha/template/captcha.vm
+++ b/jcommune-plugins/kaptcha-plugin/src/main/resources/org/jtalks/jcommune/plugin/kaptcha/template/captcha.vm
@@ -26,6 +26,6 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
   </div>
   <div class='controls'>
     <input type='text' id='${formElementId}' name='userDto.captchas[${formElementId}]'
-      placeholder='${captchaLabel}' class='input-xlarge captcha'/>
+      placeholder='${captchaLabel}' class='reg_input captcha'/>
   </div>
 </div>

--- a/jcommune-plugins/kaptcha-plugin/src/test/java/org/jtalks/jcommune/plugin/kaptcha/KaptchaPluginServiceTest.java
+++ b/jcommune-plugins/kaptcha-plugin/src/test/java/org/jtalks/jcommune/plugin/kaptcha/KaptchaPluginServiceTest.java
@@ -123,7 +123,7 @@ public class KaptchaPluginServiceTest {
         assertTrue(actual.contains("<img class='captcha-refresh' alt='Refresh captcha' "
                 + "src='http://localhost/resources/images/captcha-refresh.png'/>"));
         assertTrue(actual.contains("<input type='text' id='plugin-1' name='userDto.captchas[plugin-1]'"));
-        assertTrue(actual.contains("placeholder='Captcha text' class='input-xlarge captcha'/>"));
+        assertTrue(actual.contains("placeholder='Captcha text' class='reg_input captcha'/>"));
     }
 
     @Test

--- a/jcommune-plugins/kaptcha-plugin/src/test/java/org/jtalks/jcommune/plugin/kaptcha/KaptchaPluginTest.java
+++ b/jcommune-plugins/kaptcha-plugin/src/test/java/org/jtalks/jcommune/plugin/kaptcha/KaptchaPluginTest.java
@@ -58,7 +58,7 @@ public class KaptchaPluginTest {
                 "  </div>" + newLine +
                 "  <div class='controls'>" + newLine +
                 "    <input type='text' id='plugin-1' name='userDto.captchas[plugin-1]'" + newLine +
-                "      placeholder='Captcha text' class='input-xlarge captcha'/>" + newLine +
+                "      placeholder='Captcha text' class='reg_input captcha'/>" + newLine +
                 "  </div>" + newLine +
                 "</div>";
 

--- a/jcommune-view/jcommune-web-view/src/main/webapp/resources/javascript/app/registration.js
+++ b/jcommune-view/jcommune-web-view/src/main/webapp/resources/javascript/app/registration.js
@@ -77,8 +77,13 @@ function signUp(e) {
             Utils.createFormElement($labelPassword, 'password', 'password', null, widthStyle) +
             Utils.createFormElement($labelPasswordConfirmation, 'passwordConfirm', 'password', null, widthStyle) +
             Utils.createFormElement($lableHoneypotCaptcha, 'honeypotCaptcha', 'text', 'hide-element', widthStyle);
+        var widthStyleForPlugin = widthStyle.split(":");
         for (var pluginId in params) {
-            bodyContent += params[pluginId];
+            bodyContent += $(params[pluginId])
+                .find("input[id^='plugin']")
+                .css(widthStyleForPlugin[0], widthStyleForPlugin[1])
+                .end()
+                .prop("outerHTML");
         }
 
         var footerContent = '<button id="signup-submit-button" class="btn btn-primary btn-block" name="commit"> \


### PR DESCRIPTION
- in the HTML representation of the plugin removed the class that provides
  the size of the input field.
- in the script that creates a registration form added code that insert
  style to the captcha input field (as in the rest form inputs).
- fixed tests "testGetHtml()" of the plugin.