### PR TITLE
JC-2018 text of "Recent activity" and "Search results" have two rows

### DIFF
--- a/jcommune-view/jcommune-web-view/src/main/webapp/WEB-INF/jsp/topic/searchResult.jsp
+++ b/jcommune-view/jcommune-web-view/src/main/webapp/WEB-INF/jsp/topic/searchResult.jsp
@@ -33,11 +33,11 @@
 <body>
 <div class="container">
   <div class="row-fluid upper-pagination forum-pagination-container">
-    <div class="span3">
+    <div class="span5">
       <h3><spring:message code="label.search.header"/></h3>
     </div>
 
-    <div class="span9">
+    <div class="span7">
       <div class="pagination pull-right forum-pagination">
         <ul>
           <jtalks:pagination uri="" page="${searchResultPage}"


### PR DESCRIPTION
- replaced classes responsible for a dimension elements "div".