### PR TITLE
JC-2268 Focus on sign in/sign up pages should be on first input field

### DIFF
--- a/jcommune-view/jcommune-web-view/src/main/webapp/WEB-INF/jsp/login.jsp
+++ b/jcommune-view/jcommune-web-view/src/main/webapp/WEB-INF/jsp/login.jsp
@@ -40,7 +40,8 @@
         <label for="userName" class="control-label"><spring:message code="label.username"/> </label>
 
         <div class="controls">
-            <form:input class="reg_input" type="text" path="userName" id="dialog-userName" value="${param.username}"/>
+            <form:input class="reg_input" type="text" path="userName" id="dialog-userName" value="${param.username}"
+                    autofocus="autofocus" />
             <%-- Needed to highlight username input when login error occured--%>
             <c:if test="${not empty param.login_error}">
                 <span class="help-inline"/>

--- a/jcommune-view/jcommune-web-view/src/main/webapp/WEB-INF/jsp/registration.jsp
+++ b/jcommune-view/jcommune-web-view/src/main/webapp/WEB-INF/jsp/registration.jsp
@@ -39,7 +39,7 @@
         <span class="reg_info"><spring:message code="label.tip.username"/></span>
 
         <div class="controls">
-          <form:input path="userDto.username" class="reg_input" type="text"/>
+          <form:input path="userDto.username" class="reg_input" type="text" autofocus="autofocus" />
           <br/>
           <form:errors path="userDto.username" cssClass="help-inline"/>
         </div>

--- a/jcommune-view/jcommune-web-view/src/main/webapp/WEB-INF/jsp/restorePassword.jsp
+++ b/jcommune-view/jcommune-web-view/src/main/webapp/WEB-INF/jsp/restorePassword.jsp
@@ -41,7 +41,7 @@
         </label>
 
         <div class='controls'>
-          <form:input path="userEmail" type="text" size="20"/>
+          <form:input path="userEmail" type="text" size="20" autofocus="autofocus" />
             <br>
           <form:errors path="userEmail" cssClass="help-inline"/>
           <c:if test="${not empty message}">

--- a/jcommune-view/jcommune-web-view/src/main/webapp/resources/javascript/app/global.js
+++ b/jcommune-view/jcommune-web-view/src/main/webapp/resources/javascript/app/global.js
@@ -170,5 +170,17 @@ $(document).ready(function () {
             return dialog.outerWidth() / 2 * (-1)
         });
     });
+
+    /*
+    The first element, which have attribute "autofocus", visible, not hidden, focusable, not in focus
+    receives focus during initial page load.
+    Made to support the set focus on the element with attribute "autofocus" in browsers that do not support HTML5.
+
+    Note: there is a strange behavior when opening background tabs in Opera 12.
+     */
+    $('[autofocus]')
+        .filter(':visible:not(:hidden):focusable:not(:focus)')
+        .eq(0)
+        .focus();
 });
 


### PR DESCRIPTION
- added a code that selects the input field with the attribute
  "autofocus" of the form when page is loaded. Made to support
  the set focus on the element with attribute "autofocus" in browsers
  that do not support HTML5.
- added the attribute "autofocus" to the field "user name" on the pages:
  registration, login.
- added the attribute "autofocus" to the field "user email" on the password
  recovery page.