### PR TITLE
JC-2134 The user's selection does not work by Enter in Firefox

### DIFF
--- a/jcommune-view/jcommune-web-view/src/main/webapp/resources/javascript/app/dialog.js
+++ b/jcommune-view/jcommune-web-view/src/main/webapp/resources/javascript/app/dialog.js
@@ -322,7 +322,8 @@ $(function () {
         var tabNavigation = function (selectors) {
             $.each(selectors, function (idx, v) {
                 var func = function (e) {
-                    if ((e.keyCode || e.charCode) === tabCode) {
+                    //The "jQuery.which" property does not work on the "onkeypress" event in Firefox.
+                    if ((e.which || e.keyCode) === tabCode) {
                         e.preventDefault();
                         // to prevent infinite cycle if all element are not visible or do not exist
                         var skipCount = 0;
@@ -336,12 +337,22 @@ $(function () {
                             }
                             nextElement = jDialog.dialog.find(selectors[currentIndex]);
                             ++skipCount;
-                        } while ((nextElement.length === 0 || !nextElement.is(":visible"))
+                        } while ((nextElement.length === 0 || nextElement.is(":not(:visible)"))
                                  && skipCount <= selectors.length);
                         nextElement.focus();
                     }
                 };
-                $(v).on('keydown', func);
+
+                if($.browser.mozilla) {
+                    /*
+                    In Firefox overriding the "keydown" method with "event.preventDefault()" code inside, stops
+                    working autocomplete when pressing Tab (and another default behavior).
+                    Instead of overriding "keydown", you can use the "keypress" method.
+                     */
+                    $(v).on('keypress', func);
+                } else {
+                    $(v).on('keydown', func);
+                }
             });
         };
 


### PR DESCRIPTION
- fixed suggestion behavior in firefox.

P/S 1: found duplicated issue - JC-2213.
P/S 2: in my opinion, the below code in signin.js is redundant because the element '#restorePassSuccess' is missing (or is it groundwork for the future?):

    var success = $('#restorePassSuccess');
    if (success.length > 0) {
        var bodyContent = '\
            <div id="restore-passwd" class="control-group"> \
                <h4>' + success.val() + '</h4> \
            </div>';

        var footerContent = '<button id="restore-ok-button" class="btn btn-primary" name="confirm"> \
            ' + $labelOk + '</button>';

        var goToLoginPage = function (e) {
            if (e) {
                e.preventDefault();
            }
            window.location.href = $('.brand').attr('href') + 'login';
        };

        jDialog.createDialog({
            dialogId: 'restore-password-modal-dialog',
            closeDialog: goToLoginPage,
            bodyContent: bodyContent,
            footerContent: footerContent,
            maxWidth: 350,
            tabNavigation: ['#restore-ok-button'],
            handlers: {
                '#restore-ok-button': {'click': goToLoginPage}
            }
        });
    }
