### PR TITLE
When "isJSCompressed" is false, then webpages is displayed wrong

### DIFF
--- a/jcommune-view/jcommune-web-view/pom.xml
+++ b/jcommune-view/jcommune-web-view/pom.xml
@@ -192,6 +192,50 @@
           </deployer>
         </configuration>
       </plugin>
+      <!--This plugin used to specify resources, that need include into war file depending
+      on the value of property "isJsCompressed"-->
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-antrun-plugin</artifactId>
+        <version>1.8</version>
+        <dependencies>
+          <dependency>
+            <groupId>org.apache.ant</groupId>
+            <artifactId>ant</artifactId>
+            <version>1.9.6</version>
+          </dependency>
+          <dependency>
+            <groupId>ant-contrib</groupId>
+            <artifactId>ant-contrib</artifactId>
+            <version>1.0b3</version>
+          </dependency>
+        </dependencies>
+        <executions>
+          <execution>
+            <phase>prepare-package</phase>
+            <configuration>
+              <exportAntProperties>true</exportAntProperties>
+              <target name="Set 'excludedWebResources' property">
+                <!-- add the ant tasks from ant-contrib -->
+                <taskdef resource="net/sf/antcontrib/antlib.xml"/>
+                <if>
+                  <equals arg1="${isJsCompressed}" arg2="true"/>
+                  <then>
+                    <property name="excludedWebResources" value="resources/css/app/**,resources/css/lib/**,resources/javascript/**"/>
+                  </then>
+                  <else>
+                    <property name="excludedWebResources" value="resources/wro/**"/>
+                  </else>
+                </if>
+                <echo message="Value is: ${excludedWebResources}"/>
+              </target>
+            </configuration>
+            <goals>
+              <goal>run</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-war-plugin</artifactId>
@@ -202,7 +246,7 @@
               as well as prepare-package phase and goal exploded in execution-->
           <useCache>true</useCache>
           <packagingExcludes>
-            resources/css/app/**,resources/css/lib/**,resources/javascript/**,
+            ${excludedWebResources},
             <!-- Ignore jsp-classes compiled by jspc -->
             WEB-INF/classes/jsp/**
           </packagingExcludes>


### PR DESCRIPTION
When in the root pom file property "isJsCompressed" is set to "false", the web application must not use compressed resources. As a result of the use of such resources - is that webpages is not displayed correctly.
This change fixes this problem.