### PR TITLE
JC-2276 Disable email notification after deleting post

### DIFF
--- a/jcommune-service/src/main/java/org/jtalks/jcommune/service/nontransactional/NotificationService.java
+++ b/jcommune-service/src/main/java/org/jtalks/jcommune/service/nontransactional/NotificationService.java
@@ -85,17 +85,16 @@ public class NotificationService {
     /**
      * Overload for skipping topic subscribers
      *
-     * @param entity
-     * @param topicSubscribers
+     * @param entity changed subscribed entity.
+     * @param excludeFromNotification a collection of subscribers who are excluded from a notification.
      */
-    public void subscribedEntityChanged(SubscriptionAwareEntity entity, Collection<JCUser> topicSubscribers) {
+    public void subscribedEntityChanged(SubscriptionAwareEntity entity, Collection<JCUser> excludeFromNotification) {
         Collection<JCUser> subscribers = subscriptionService.getAllowedSubscribers(entity);
+        subscribers.removeAll(excludeFromNotification);
         filterSubscribers(subscribers, entity);
 
         for (JCUser user : subscribers) {
-            if (!topicSubscribers.contains(user)) {
-                mailService.sendUpdatesOnSubscription(user, entity);
-            }
+            mailService.sendUpdatesOnSubscription(user, entity);
         }
     }
 

--- a/jcommune-service/src/test/java/org/jtalks/jcommune/service/nontransactional/NotificationServiceTest.java
+++ b/jcommune-service/src/test/java/org/jtalks/jcommune/service/nontransactional/NotificationServiceTest.java
@@ -28,10 +28,12 @@ import org.testng.annotations.Test;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 
 import static org.mockito.Mockito.*;
 import static org.mockito.MockitoAnnotations.initMocks;
 import static org.testng.Assert.assertEquals;
+import static org.unitils.reflectionassert.ReflectionAssert.assertReflectionEquals;
 
 /**
  * @author Evgeniy Naumenko
@@ -201,14 +203,14 @@ public class NotificationServiceTest {
         topic.getSubscribers().add(currentUser);
         when(subscriptionService.getAllowedSubscribers(topic)).thenReturn(topic.getSubscribers());
 
-        Collection<JCUser> topicSubscribers = new ArrayList();
-        topicSubscribers.add(user2);
+        Collection<JCUser> excludeFromNotification = new ArrayList();
+        excludeFromNotification.add(user2);
 
-        service.subscribedEntityChanged(topic, topicSubscribers);
+        service.subscribedEntityChanged(topic, excludeFromNotification);
 
-        verify(mailService, times(1)).sendUpdatesOnSubscription(any(JCUser.class), eq(topic));
+        verify(mailService).sendUpdatesOnSubscription(any(JCUser.class), eq(topic));
         verify(mailService).sendUpdatesOnSubscription(user1, topic);
-        assertEquals(topic.getSubscribers().size(), 2);
+        assertReflectionEquals(Collections.singleton(user1), topic.getSubscribers());
     }
     
     @Test


### PR DESCRIPTION
- when you delete a post, a notification is sent only to the user who
  created it. If the user (owner of the post) deletes the post, no notification is sent.