### PR TITLE
JC-2263 Pop-up window Sign up: Press Enter don`t choose a suggestion in list of suggestions

### DIFF
--- a/jcommune-view/jcommune-web-view/src/main/webapp/resources/javascript/app/registration.js
+++ b/jcommune-view/jcommune-web-view/src/main/webapp/resources/javascript/app/registration.js
@@ -158,6 +158,11 @@ function signUp(e) {
                 handlers: {
                     '#signup-submit-button': {'click': submitFunc},
                     '.btn-captcha-refresh, .captcha-img': {'click' : refreshCaptcha, 'keydown': refreshCaptchaKeyHandler}
+                },
+                dialogKeydown: function (e) {
+                    if (e.which == escCode) {
+                        jDialog.dialog.find('.close').click();
+                    }
                 }
             });
         }


### PR DESCRIPTION
- replaced the default "keydown" method of dialogue (with code
  "event.preventDefault()" inside), that breaks Firefox default suggestions
  behavior.