### PR TITLE
JC-2281 Error "User not found" error when the recipient is selected from list by the mouse

### DIFF
--- a/jcommune-view/jcommune-web-view/src/main/webapp/resources/javascript/app/contextMenu.js
+++ b/jcommune-view/jcommune-web-view/src/main/webapp/resources/javascript/app/contextMenu.js
@@ -39,25 +39,11 @@ jQuery(document).ready(function () {
             $(".ui-menu-item").removeClass("custom-selected-item");
             $("#ui-active-menuitem").parent().addClass("custom-selected-item");
             $("#ui-active-menuitem").removeClass("ui-corner-all");
+        },
+        change: function(e, ui) {
+            validateRecipient();
         }
     }).autocomplete("widget").addClass("suggestion-list");
-
-    var mousedownHappened = false;
-    var mousedownTarget;
-
-    $("input, a").mousedown(function(e) {
-        mousedownHappened = true;
-        mousedownTarget = $(this);
-    });
-
-    recipientField.focusout(function() {
-        validateRecipient();
-        //needed because there are problems with click event after blur or focusout
-        if (mousedownHappened) {
-            mousedownHappened = false;
-            mousedownTarget.click();
-        }
-    });
 
     function validateRecipient() {
         clearError();


### PR DESCRIPTION
- deleted "focusout" event handler of the fields "recipient", which is triggered before "select" events of the autocomplete widget. Instead, I added an event handler "change" to the autocomplete widget, that is triggered when the field is blurred, if the value has changed.