### PR TITLE
JC-2274 Fixed bug: validation message about field length in drafts after changing focus doesn't disappear after deleting extra symbol

### DIFF
--- a/jcommune-view/jcommune-web-view/src/main/webapp/resources/javascript/app/postDraft.js
+++ b/jcommune-view/jcommune-web-view/src/main/webapp/resources/javascript/app/postDraft.js
@@ -96,7 +96,7 @@
         this._savingTimer = new draft.IntervalTimer(this.save.bind(this), SAVE_INTERVAL);
 
         this._bodyText.on('blur', this._onBlur.bind(this));
-        this._bodyText.on('keyup', this._onKeyUp.bind(this));
+        this._bodyText.on('input', this._onInput.bind(this));
     }
 
     /**
@@ -222,12 +222,8 @@
         }
     };
 
-    PostDraft.prototype._onKeyUp = function (event) {
+    PostDraft.prototype._onInput = function (event) {
         var self = this;
-
-        if (!this.wasChanged()) {
-            return;
-        }
 
         // Remove draft if user emptied content (for instance by Ctrl-A and Backspace)
         if ($(event.target).is(this._bodyText) && this._bodyText.val().length == 0) {

--- a/jcommune-view/jcommune-web-view/src/main/webapp/resources/javascript/app/topicDraft.js
+++ b/jcommune-view/jcommune-web-view/src/main/webapp/resources/javascript/app/topicDraft.js
@@ -92,9 +92,6 @@
      * @constructor
      */
     function TopicDraft(api, counter, popup) {
-
-        var self = this;
-
         this._api = api;
         this._counter = counter;
         this._popup = popup;
@@ -142,7 +139,7 @@
         }
 
         this._addEventListener('blur', this._onBlur.bind(this));
-        this._addEventListener('keyup', this._onKeyUp.bind(this));
+        this._addEventListener('input', this._onInput.bind(this));
     }
 
     /**
@@ -240,10 +237,8 @@
         success &= validateStringField('content', MAX_CONTENT_LENGTH, CONTENT_ERROR_MESSAGE);
         success &= validateStringField('pollTitle', MAX_POLL_TITLE_LENGTH, POLL_TITLE_ERROR_MESSAGE);
 
-        function hideErrorIfFieldWasChanged(name) {
-            if (self._fieldWasChanged(name)) {
-                self._hideError(name);
-            }
+        function hideFieldError(name) {
+            self._hideError(name);
         }
 
         function validateStringField(name, max, message) {
@@ -251,7 +246,7 @@
                 self._showError(name, message);
                 return false;
             } else {
-                hideErrorIfFieldWasChanged(name);
+                hideFieldError(name);
                 return true;
             }
         }
@@ -263,7 +258,7 @@
                 this._showError('pollItemsValue', POLL_ITEMS_VALUE_ERROR_MESSAGE);
                 success = false;
             } else {
-                hideErrorIfFieldWasChanged('pollItemsValue');
+                hideFieldError('pollItemsValue');
             }
 
             if (success) {
@@ -276,11 +271,11 @@
                 if (!success) {
                     this._showError('pollItemsValue', POLL_ITEM_LENGTH_ERROR);
                 } else {
-                    hideErrorIfFieldWasChanged('pollItemsValue');
+                    hideFieldError('pollItemsValue');
                 }
             }
         } else {
-            hideErrorIfFieldWasChanged('pollItemsValue');
+            hideFieldError('pollItemsValue');
         }
 
         return success;
@@ -369,12 +364,8 @@
         }
     };
 
-    TopicDraft.prototype._onKeyUp = function (event) {
+    TopicDraft.prototype._onInput = function (event) {
         var self = this;
-
-        if (!this.wasChanged()) {
-            return;
-        }
 
         // Remove draft if user emptied content (for instance by Ctrl-A and Backspace)
         if (this._isEmpty()) {


### PR DESCRIPTION
Bug reason: function "wasChanged" compares the value of the field with the stored draft values rather than actual, so validation does not occur when deleting extra symbol

Solution: listen "input" event instead "onKeyUp" event, because "input" event triggered only if field changed