### PR TITLE
JC-2285 Fixed bug: Text of editing comment in QnA topics appears after cancelling edit and trying re-edit

### DIFF
--- a/jcommune-plugins/questions-n-answers-plugin/src/main/resources/org/jtalks/jcommune/plugin/questionsandanswers/template/js/question.js
+++ b/jcommune-plugins/questions-n-answers-plugin/src/main/resources/org/jtalks/jcommune/plugin/questionsandanswers/template/js/question.js
@@ -228,6 +228,7 @@ var editSubmitHandler = function(e) {
         success: function(data) {
             if(data.status == 'SUCCESS') {
                 $("#body-" + commentId).text(data.result);
+                $("#editable-" + commentId).text(data.result);
                 enableViewMode(commentId);
             } else if (data.reason == 'VALIDATION') {
                 enableEditMode(commentId);
@@ -255,7 +256,12 @@ var editCancelHandler = function(e) {
     }
 
     hideVisibleEditPrompts();
+
     var commentId = $(this).attr("data-comment-id");
+
+    var textarea = $('#editable-' + commentId); // cancel text change
+    textarea.val(textarea.text());
+
     enableViewMode(commentId);
 }
 


### PR DESCRIPTION
Bug reason: confusion with "val()" and "text()" of textarea element, when cancel editing "val" stay changed

Solution: reset "val()" to "text()" when canceling edit and update "text()" when save comment