### PR TITLE
JC-2194 Got rid of drop-down menu of "Code" button

### DIFF
--- a/jcommune-plugin-api/src/main/resources/org/jtalks/jcommune/jcommune-plugin-api/web/templates/bbeditor.vm
+++ b/jcommune-plugin-api/src/main/resources/org/jtalks/jcommune/jcommune-plugin-api/web/templates/bbeditor.vm
@@ -100,27 +100,10 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
          title="<jcommune:message>label.answer.insert_link</jcommune:message>">
         <i class="icon-link"></i>
       </a>
-
-      <a class="btn dropdown-toggle" data-toggle="dropdown" href="#fake"
-              title="<jcommune:message>label.answer.font_code</jcommune:message>">
+      <a id='select_code' class="btn" href="#fake"
+         title="<jcommune:message>label.answer.font_code</jcommune:message>">
         <jcommune:message>label.answer.font_code.button</jcommune:message>
-        <span class="caret"></span>
       </a>
-      <ul class="dropdown-menu" id='select_code'>
-        <li data-value="cpp"><a href="#fake">C/C++</a></li>
-        <li data-value="csharp"><a href="#fake">C#</a></li>
-        <li data-value="java"><a href="#fake">Java</a></li>
-        <li data-value="php"><a href="#fake">PHP</a></li>
-        <li data-value="python"><a href="#fake">Python</a></li>
-        <li data-value="pascal"><a href="#fake">Pascal</a></li>
-        <li data-value="bash"><a href="#fake">Bash</a></li>
-        <li data-value="js"><a href="#fake">JavaScript</a></li>
-        <li data-value="html"><a href="#fake">HTML</a></li>
-        <li data-value="css"><a href="#fake">CSS</a></li>
-        <li data-value="sql"><a href="#fake">SQL</a></li>
-        <li data-value="xml"><a href="#fake">XML</a></li>
-      </ul>
-
       <a id="format_quote" class="btn" accesskey="q" href="#fake"
         title="<jcommune:message>label.answer.quote</jcommune:message>">
         <i class="icon-quote"></i>

--- a/jcommune-service/src/main/resources/kefirbb-strip-config.xml
+++ b/jcommune-service/src/main/resources/kefirbb-strip-config.xml
@@ -313,7 +313,7 @@ get XSS attacks.</p>-->
 
     <!-- Code block -->
     <code name="code">
-        <pattern ignoreCase="true">[code=<var name="lang"/>]<var name="code" scope="escapeXml"/>[/code]</pattern>
+        <pattern ignoreCase="true">[code<var name="lang"/>]<var name="code" scope="escapeXml"/>[/code]</pattern>
         <template><var name="code"/></template>
     </code>
 

--- a/jcommune-service/src/main/resources/kefirbb.xml
+++ b/jcommune-service/src/main/resources/kefirbb.xml
@@ -314,7 +314,7 @@ get XSS attacks.</p>-->
 
     <!-- Code block -->
     <code name="code">
-        <pattern ignoreCase="true">[code=<var name="lang"/>]<var name="code" scope="escapeXml"/>[/code]</pattern>
+        <pattern ignoreCase="true">[code<var name="lang"/>]<var name="code" scope="escapeXml"/>[/code]</pattern>
         <template>&lt;pre class=&quot;prettyprint linenums <var name="lang"/>&quot;&gt;<var name="code"/>&lt;/pre&gt;</template>
     </code>
 

--- a/jcommune-service/src/test/java/org/jtalks/jcommune/service/nontransactional/BBCodeServiceTest.java
+++ b/jcommune-service/src/test/java/org/jtalks/jcommune/service/nontransactional/BBCodeServiceTest.java
@@ -127,7 +127,7 @@ public class BBCodeServiceTest {
                         "<a title=\"\" href=\"http://narod.ru/avatar.jpg\" class=\"pretty-photo\">" +
                                 "<img class=\"thumbnail\" alt=\"\" src=\"http://narod.ru/avatar.jpg\" onError=\"imgError(this)\" /></a>"},
                 //code
-                {"[code=sql]println(\"Hi!\");[/code]", "<pre class=\"prettyprint linenums sql\">println(&quot;Hi!&quot;);</pre>"},
+                {"[code]println(\"Hi!\");[/code]", "<pre class=\"prettyprint linenums \">println(&quot;Hi!&quot;);</pre>"},
                 //qoutes
                 {"[quote]Some text[/quote]",
                         "<div class=\"quote bb_quote_container\"><span class=\"bb_quote_title\">Quote:" +

--- a/jcommune-view/jcommune-web-view/src/main/webapp/WEB-INF/tags/bbeditor.tag
+++ b/jcommune-view/jcommune-web-view/src/main/webapp/WEB-INF/tags/bbeditor.tag
@@ -105,25 +105,10 @@
       <i class="icon-link"></i>
     </a>
 
-    <a class="btn dropdown-toggle" data-toggle="dropdown" href="#fake"
+    <a id='select_code' class="btn" href="#fake"
        title="<spring:message code='label.answer.font_code'/>">
       <spring:message code="label.answer.font_code.button"/>
-      <span class="caret"></span>
     </a>
-    <ul class="dropdown-menu" id='select_code'>
-      <li data-value="cpp"><a href="#fake">C/C++</a></li>
-      <li data-value="csharp"><a href="#fake">C#</a></li>
-      <li data-value="java"><a href="#fake">Java</a></li>
-      <li data-value="php"><a href="#fake">PHP</a></li>
-      <li data-value="python"><a href="#fake">Python</a></li>
-      <li data-value="pascal"><a href="#fake">Pascal</a></li>
-      <li data-value="bash"><a href="#fake">Bash</a></li>
-      <li data-value="js"><a href="#fake">JavaScript</a></li>
-      <li data-value="html"><a href="#fake">HTML</a></li>
-      <li data-value="css"><a href="#fake">CSS</a></li>
-      <li data-value="sql"><a href="#fake">SQL</a></li>
-      <li data-value="xml"><a href="#fake">XML</a></li>
-    </ul>
 
     <a id="format_quote" class="btn" accesskey="q" href="#fake"
        title="<spring:message code='label.answer.quote'/>">

--- a/jcommune-view/jcommune-web-view/src/main/webapp/resources/javascript/lib/wysiwyg-bbcode/editor.js
+++ b/jcommune-view/jcommune-web-view/src/main/webapp/resources/javascript/lib/wysiwyg-bbcode/editor.js
@@ -261,10 +261,9 @@ function doSize(selectedElement) {
     }
 }
 
-function doCode(selectedElement) {
+function doCode() {
     if (!editorVisible) {
-		var code = $(selectedElement).parent().attr('data-value');
-        addTag('[code=' + code + ']', '[/code]');
+		addTag('[code]', '[/code]');
     }
 }
 
@@ -754,6 +753,7 @@ $(document).ready(function() {
         format_right: function(){doClick('right');},
         format_list: function(){doClick('InsertUnorderedList');},
         format_listeq: function(){doClick('listElement');},
+        select_code: function(){doCode();},
         format_quote: function(){doQuote();}
     }
 
@@ -766,10 +766,6 @@ $(document).ready(function() {
 
     $('#select_size a').click(function() {
             doSize(this);
-    });
-
-    $('#select_code a').click(function() {
-            doCode(this);
     });
 
     $('#select_indent a').click(function() {


### PR DESCRIPTION
There is no more "Add syntax higlight" button described in the topic of
this task in Jira, this button's name is "Code".
Got rid of drop-down menu because it does not matter what programming
language we choose in the drop-down list of button "Code". The syntax will
be displayed correct depending on what language it is written.
Pressing button "Code" you will have this construction: [code=]Insert your
text here[/code]
Still old version of constraction e.g [code=java]Insert your text
here[/code] is working correctly too.
modified files:
  jcommune-view/jcommune-web-view/src/main/webapp/WEB-INF/tags/bbeditor.tag
  jcommune-view/jcommune-web-view/src/main/webapp/resources/javascript/lib/wysiwyg-bbcode/editor.js