### PR TITLE
JC-2170 Wrong tags for sintax highlight in Opera12

### DIFF
--- a/jcommune-view/jcommune-web-view/src/main/webapp/WEB-INF/tags/bbeditor.tag
+++ b/jcommune-view/jcommune-web-view/src/main/webapp/WEB-INF/tags/bbeditor.tag
@@ -47,7 +47,7 @@
       <i class="icon-strike"></i>
     </a>
     <a id="format_highlight" class="btn" accesskey="h" href="#fake"
-       title='<spring:message code='label.answer.highlight'/>'>
+       title="<spring:message code='label.answer.highlight'/>">
       <spring:message code='label.answer.highlight.button'/>
     </a>
   </div>

--- a/jcommune-view/jcommune-web-view/src/main/webapp/resources/javascript/lib/wysiwyg-bbcode/editor.js
+++ b/jcommune-view/jcommune-web-view/src/main/webapp/resources/javascript/lib/wysiwyg-bbcode/editor.js
@@ -468,10 +468,11 @@ function addTag(t1, t2, selection) {
         sel_start = element.selectionStart;
         sel_end = element.selectionEnd;
 
-        if (element.value == "" && $.browser.opera) {
-            // for Opera browser null value (textarea empty) for selectionStart and selectionEnd is '20'
-            sel_start = sel_start - 20;
-            sel_end = sel_end - 20;
+        if (element.value == "") {
+            // some browsers could have selectionStart and selectionEnd that is not equal to 0 for empty textarea
+            // e.g. opera 12 has 15. So it's better to assign 0 in order not to have problems in the future
+            sel_start = 0;
+            sel_end = 0;
         }
 
         insertText(element, t1, sel_start);


### PR DESCRIPTION
Some browsers could have selectionStart and selectionEnd that is not equal
to 0 for empty textarea.
E.g. opera 12 has 15. So it's better to assign 0 in order not to have
problems in the future.
I also incidentally found and corrected an inaccuracy in the file
bbeditor.tag.
It was
   `title='<spring:message code='label.answer.highlight'/>'>`
changed to
   `title="<spring:message code='label.answer.highlight'/>">`