### PR TITLE
JC-2292 Group add and delete security fix

### DIFF
--- a/jcommune-view/jcommune-web-view/src/main/webapp/WEB-INF/security-context.xml
+++ b/jcommune-view/jcommune-web-view/src/main/webapp/WEB-INF/security-context.xml
@@ -46,7 +46,7 @@
     <security:intercept-url pattern="/user" method="GET" access="isAuthenticated()"/>
     <security:intercept-url pattern="/user/" method="GET" access="isAuthenticated()"/>
     <security:intercept-url pattern="/user/*/groups" method="GET" access="isAuthenticated()"/>
-    <security:intercept-url pattern="/user/*/groups/*" method="GET" access="isAuthenticated()"/>
+    <security:intercept-url pattern="/user/*/groups/*" access="isAuthenticated()"/>
     <security:intercept-url pattern="/users/**" access="isAuthenticated()"/>
     <security:intercept-url pattern="/user/activate/**" access="permitAll()"/>
 


### PR DESCRIPTION
In file `security-context.xml` rule for `/user/*/groups/*` mask configured only for `GET `methods. But add and delete requests type `POST `and `DELETE`. Now rule shared for all methods.