### PR TITLE
JC-2309 Notifications bug fix

### DIFF
--- a/jcommune-view/jcommune-web-view/src/main/webapp/resources/javascript/app/forumAdministration.js
+++ b/jcommune-view/jcommune-web-view/src/main/webapp/resources/javascript/app/forumAdministration.js
@@ -146,7 +146,7 @@ function getCurrentAdminValues() {
         copyright: $("#copyrightHolder").text() || "",
         sessionTimeout: $("#sessionTimeoutHolder").text() || "",
         avatarMaxSize: $("#avatarMaxSizeHolder").text() || "",
-        emailNotification: !!$("#emailNotificationHolder").text()
+        emailNotification: $("#emailNotificationHolder").text()
     }
 }
 
@@ -262,7 +262,7 @@ function createAdministrationDialog() {
             e.preventDefault();
             $("#uploadLogo").focus();
         }
-    }
+    };
     $("#" + jDialog.options.dialogId).on('keydown', tabFunc);
 
     fillAdminDialogInputs();
@@ -300,7 +300,7 @@ function fillAdminDialogInputs() {
     $('#forumCopyright').val(currentAdminValues.copyright);
     $('#forumSessionTimeout').val(currentAdminValues.sessionTimeout);
     $('#forumAvatarMaxSize').val(currentAdminValues.avatarMaxSize);
-    $('#forumEmailNotification').prop('checked', currentAdminValues.emailNotification === true);
+    $('#forumEmailNotification').prop('checked', currentAdminValues.emailNotification === 'true');
 }
 
 /*


### PR DESCRIPTION
I fixed the problem with checkbox email notifications.
The cause of this problem is was a comparing admin value 'emailNotification' as a boolean(=== true),
but need to compare this as a String(=== 'true') because the return value type of 'emailNotification' is a String.
Actual result if email notifications is disabled - checkbox is 'unchecked'