### PR TITLE
Fix working of the web resource optimizer on Windows platforms

### DIFF
--- a/jcommune-view/jcommune-web-view/pom.xml
+++ b/jcommune-view/jcommune-web-view/pom.xml
@@ -142,7 +142,7 @@
       <plugin>
         <groupId>ro.isdc.wro4j</groupId>
         <artifactId>wro4j-maven-plugin</artifactId>
-        <version>1.7.5</version>
+        <version>1.7.6</version>
         <executions>
           <execution>
             <phase>generate-resources</phase>
@@ -157,7 +157,7 @@
           <destinationFolder>${basedir}/src/main/webapp/resources/wro</destinationFolder>
           <cssDestinationFolder>${basedir}/src/main/webapp/resources/wro</cssDestinationFolder>
           <jsDestinationFolder>${basedir}/src/main/webapp/resources/wro</jsDestinationFolder>
-          <contextFolder>${basedir}/src/main/webapp/</contextFolder>
+          <contextFolder>${basedir}/src/main/webapp/,${basedir}\src\main\webapp\</contextFolder>
           <wroFile>${basedir}/wro.xml</wroFile>
           <wroManagerFactory>
             ro.isdc.wro.extensions.manager.standalone.GoogleStandaloneManagerFactory


### PR DESCRIPTION
The web resource optimizer (wro4j-maven-plugin) not correctly rewrites
URLs of resources in css-files on Windows platforms. As a result,
resources become unavailable and user, for example, does not sees
the icons on the toolbar buttons. The behavior is due to incorrect
`contextFolder` variable definition inside plugin
(bug report: https://github.com/wro4j/wro4j/issues/1021).

To solve described problem made the following changes:

- added the path for `contextFolder` parameter specified in Windows style
(with back slashes) to pom.xml:
```xml
<contextFolder>${basedir}/src/main/webapp/,${basedir}\src\main\webapp\</contextFolder>
```

- changed version of wro4j-maven-plugin from 1.7.5 to 1.7.6, because
old versions of the plugin have additional bug associated with
described problem.