### PR TITLE
JC-2309 Fixed wrong focus navigation through administration popup

### DIFF
--- a/jcommune-view/jcommune-web-view/src/main/webapp/resources/javascript/app/forumAdministration.js
+++ b/jcommune-view/jcommune-web-view/src/main/webapp/resources/javascript/app/forumAdministration.js
@@ -240,7 +240,7 @@ function createAdministrationDialog() {
         maxHeight: 700,
         firstFocus: true,
         tabNavigation: ['#forumName', '#forumDescription', '#forumTitlePrefix', '#forumLogoTooltip', '#forumCopyright',
-            '#sessionTimeout', '#avatarMaxSize', '#emailNotification',
+            '#forumSessionTimeout', '#forumAvatarMaxSize', '#forumEmailNotification',
             '#administrationSubmitButton', '#administrationCancelButton'],
         handlers: {
             '#administrationSubmitButton': {'click': sendForumConfiguration},


### PR DESCRIPTION
Ids of some html components were mistaken within 'tabNavigation' property.