### PR TITLE
JC-2289 XSS vulnerability at profile page bug fix

### DIFF
--- a/jcommune-view/jcommune-web-view/src/main/webapp/WEB-INF/jsp/editProfile.jsp
+++ b/jcommune-view/jcommune-web-view/src/main/webapp/WEB-INF/jsp/editProfile.jsp
@@ -27,7 +27,7 @@
   <meta name="description" content="<c:out value="${label.user}"/>">
   <title>
     <c:out value="${cmpTitlePrefix}"/>
-    <spring:message code="label.user"/> - "${editedUser.username}"
+    <spring:message code="label.user"/> - <c:out value="${editedUser.username}"/>
   </title>
 </head>
 <body>


### PR DESCRIPTION
Included JSTL's c:out tag for
${editedUser.username} expression
in editProfile.jsp. Because this tag
escapes HTML characters for
avoid cross-site scripting.