### PR TITLE
JC-2005 Fixed multiple clicking on 'Mark all as read'

### DIFF
--- a/jcommune-view/jcommune-web-controller/src/test/java/org/jtalks/jcommune/web/controller/ReadPostsControllerTest.java
+++ b/jcommune-view/jcommune-web-controller/src/test/java/org/jtalks/jcommune/web/controller/ReadPostsControllerTest.java
@@ -27,6 +27,7 @@ import static org.mockito.MockitoAnnotations.initMocks;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import org.springframework.retry.policy.NeverRetryPolicy;
 import org.springframework.retry.support.RetryTemplate;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
@@ -47,6 +48,8 @@ public class ReadPostsControllerTest {
     @BeforeMethod
     public void init() {
         initMocks(this);
+        retryTemplate = new RetryTemplate();
+        retryTemplate.setRetryPolicy(new NeverRetryPolicy());
         controller = new ReadPostsController(branchService, lastReadPostService, retryTemplate);
     }
     


### PR DESCRIPTION
RetryPolicy changed
According to javadoc for tests purpose recommended to use NeverRetryPolicy
changes made in ReadPostsControllerTest.java