### PR TITLE
JC-2291.MigrationToUtf8mb4

### DIFF
--- a/jcommune-model/src/main/resources/org/jtalks/jcommune/migrations/V65__Add_admin_user.sql
+++ b/jcommune-model/src/main/resources/org/jtalks/jcommune/migrations/V65__Add_admin_user.sql
@@ -1,3 +1,5 @@
+-- SET NAMES used to avoid Illegal mix of collations error when '=' operator is called
+SET NAMES 'utf8mb4' COLLATE 'utf8mb4_unicode_ci';
 set @adminUserName := 'admin';
 set @adminPassword := 'admin';
 set @adminGroupName := 'Administrators';
@@ -12,7 +14,7 @@ set @forumComponentAclClass :='COMPONENT';
 set @forumComponentId := 2;
 set @availableUsersText := 'Available users: admin/admin';
 set @isPrincipal := true;
-set @notPricipal := false;
+set @notPrincipal := false;
 set @adminMask := 16;
 
 insert into COMPONENTS (CMP_ID, COMPONENT_TYPE, UUID, `NAME`, DESCRIPTION)

--- a/jcommune-model/src/main/resources/org/jtalks/jcommune/migrations/V73__Convert_Database_To_UTF8MB4_Encoding.sql
+++ b/jcommune-model/src/main/resources/org/jtalks/jcommune/migrations/V73__Convert_Database_To_UTF8MB4_Encoding.sql
@@ -1,0 +1,39 @@
+DELIMITER $$
+DROP PROCEDURE IF EXISTS changeCollation$$
+-- Stored procedure to convert all tables character set and collations
+CREATE PROCEDURE changeCollation(IN character_set VARCHAR(255), IN collation_type VARCHAR(255))
+  BEGIN
+    DECLARE is_finished INTEGER DEFAULT 0;
+    DECLARE tableName varchar(255) DEFAULT "";
+    DECLARE t_cursor CURSOR FOR SELECT DISTINCT TABLE_NAME
+                                    FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = DATABASE()
+                                                                          AND TABLE_TYPE = "BASE TABLE";
+    DECLARE CONTINUE HANDLER
+    FOR NOT FOUND SET is_finished = 1;
+    OPEN t_cursor;
+
+    get_table: LOOP
+      FETCH t_cursor INTO tableName;
+      IF is_finished = 1 THEN
+        LEAVE get_table;
+      END IF;
+-- Flyway cannot convert schema_version table by self because it uses 'SELECT FOR UPDATE' query inside the lib.
+      IF (tableName != '' AND tableName != 'jcommune_schema_version') THEN
+
+        SET @s = CONCAT('ALTER TABLE ', tableName,
+                        ' CONVERT TO CHARACTER SET ', character_set, ' COLLATE ', collation_type);
+        PREPARE stmt FROM @s;
+        EXECUTE stmt;
+        DEALLOCATE PREPARE stmt;
+        SET tableName = '';
+
+      END IF;
+    END LOOP get_table;
+    CLOSE t_cursor;
+  END $$
+DELIMITER ;
+
+ALTER DATABASE CHARACTER SET 'utf8mb4' COLLATE 'utf8mb4_unicode_ci';
+SET FOREIGN_KEY_CHECKS = 0;
+CALL changeCollation('utf8mb4','utf8mb4_unicode_ci');
+SET FOREIGN_KEY_CHECKS = 1;

--- a/jcommune-model/src/main/resources/org/jtalks/jcommune/model/sample-forum.sql
+++ b/jcommune-model/src/main/resources/org/jtalks/jcommune/model/sample-forum.sql
@@ -1,4 +1,10 @@
-﻿SET @forum_component_id := 2;
+﻿# We have collation_connection = utf8mb4_general_ci by default and if user has SUPER privileges then
+# init-connect command in mysql config file has no effect (only for SUPER users) and we need to set up
+# collation_connection to utf8mb4_unicode_ci to prevent Illegal Mix of Collations for '=' operations,
+# because on the one hand we have utf8mb4_general_ci and utf8mb4_unicode_ci on the other.
+SET NAMES 'utf8mb4' COLLATE 'utf8mb4_unicode_ci';
+
+SET @forum_component_id := 2;
 -- Update description of FORUM component for new users baing created
 update COMPONENTS set DESCRIPTION = 'Available users: admin/admin registered/registered moderator/moderator banned/banned and others'
   where CMP_ID = @forum_component_id;

--- a/jcommune-view/jcommune-web-view/src/main/resources/org/jtalks/jcommune/model/datasource.properties
+++ b/jcommune-view/jcommune-web-view/src/main/resources/org/jtalks/jcommune/model/datasource.properties
@@ -2,7 +2,7 @@
 #Other properties that can be read only from this properties file are using such.usual_convention
 
 jdbc.driverClassName=com.mysql.jdbc.Driver
-JCOMMUNE_DB_URL=jdbc:mysql://localhost:3306/jtalks?characterEncoding=UTF-8
+JCOMMUNE_DB_URL=jdbc:mysql://localhost:3306/jtalks
 #JCOMMUNE_DB_USER=root
 #JCOMMUNE_DB_PASSWORD=
 encoding=utf-8

--- a/jcommune-view/jcommune-web-view/src/main/webapp/WEB-INF/jsp/groupAdministration.jsp
+++ b/jcommune-view/jcommune-web-view/src/main/webapp/WEB-INF/jsp/groupAdministration.jsp
@@ -19,7 +19,6 @@
 <%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
 <%@ page contentType="text/html;charset=UTF-8" language="java" %>
 
-<html>
 <head>
     <title>
         <c:out value="${cmpTitlePrefix}"/>
@@ -29,6 +28,7 @@
 <body>
 
 <div class="container">
+    <h2><spring:message code="label.administration.userGroups"/> </h2>
     <table class="table table-bordered grid-table display" id="userGroups">
         <thead>
         <tr>
@@ -45,4 +45,3 @@
     </table>
 </div>
 </body>
-</html>


### PR DESCRIPTION
### Notes
Previously jcommune used 'UTF-8' character set. But due to [JC-2001] Entering smile from mobile keypad
leads to Error 500, we wanted to change database character set to 'utf8mb4'. Also due to [JC-2321]
Usergroups list order is case-sensitive, collation must be 'utf8mb4_unicode_ci'.

### Functionality Added or Changed

- Now default database character set is 'utf8mb4' and collation 'utf8mb4_unicode_ci'
- All tables in the database converted to character set 'utf8mb4' and collation 'utf8mb4_unicode_ci', except jcommune_schema_version, because it is blocked by flyway.
- Removed characterEncoding parameter from jdbc connection url because since version 5.1.13 Connector/J did not support utf8mb4 for servers 5.5.2 and newer. Now it takes from the server settings. (https://dev.mysql.com/doc/relnotes/connector-j/5.1/en/news-5-1-13.html).

### Bugs Fixed
- Removed reduntand <html> tag from groupAdministration.jsp
- Fixed [JC-2001] Entering smile from mobile keypad leads to Error 500
- Fixed [JC-2321] Usergroups list order is case-sensitive