### PR TITLE
JC-970 Re-indexing is not secured

### DIFF
--- a/jcommune-service/src/main/java/org/jtalks/jcommune/service/transactional/TransactionalTopicFetchService.java
+++ b/jcommune-service/src/main/java/org/jtalks/jcommune/service/transactional/TransactionalTopicFetchService.java
@@ -23,6 +23,7 @@ import org.jtalks.jcommune.model.entity.Branch;
 import org.jtalks.jcommune.model.entity.JCUser;
 import org.jtalks.jcommune.model.entity.Topic;
 import org.jtalks.jcommune.plugin.api.service.PluginTopicFetchService;
+import org.jtalks.jcommune.service.ComponentService;
 import org.jtalks.jcommune.service.TopicFetchService;
 import org.jtalks.jcommune.service.UserService;
 import org.jtalks.jcommune.plugin.api.exceptions.NotFoundException;
@@ -40,16 +41,19 @@ import java.util.List;
 public class TransactionalTopicFetchService extends AbstractTransactionalEntityService<Topic, TopicDao>
         implements TopicFetchService, PluginTopicFetchService {
 
+    private ComponentService componentService;
     private UserService userService;
     private TopicSearchDao searchDao;
 
     /**
      * @param dao         topic dao for database manipulations
+     * @param componentService to checking user permissions
      * @param userService to get current user and his preferences
      * @param searchDao   for search index access
      */
-    public TransactionalTopicFetchService(TopicDao dao, UserService userService, TopicSearchDao searchDao) {
+    public TransactionalTopicFetchService(TopicDao dao, ComponentService componentService, UserService userService, TopicSearchDao searchDao) {
         super(dao);
+        this.componentService = componentService;
         this.userService = userService;
         this.searchDao = searchDao;
     }
@@ -126,6 +130,8 @@ public class TransactionalTopicFetchService extends AbstractTransactionalEntityS
      */
     @Override
     public void rebuildSearchIndex() {
+        long componentId = componentService.getComponentOfForum().getId();
+        componentService.checkPermissionsForComponent(componentId);
         searchDao.rebuildIndex();
     }
     

--- a/jcommune-service/src/main/resources/org/jtalks/jcommune/service/applicationContext-service.xml
+++ b/jcommune-service/src/main/resources/org/jtalks/jcommune/service/applicationContext-service.xml
@@ -238,6 +238,7 @@
   <bean id="topicFetchService"
         class="org.jtalks.jcommune.service.transactional.TransactionalTopicFetchService">
     <constructor-arg ref="topicDao"/>
+    <constructor-arg ref="componentService"/>
     <constructor-arg ref="userService"/>
     <constructor-arg ref="topicSearchDao"/>
   </bean>

--- a/jcommune-service/src/test/java/org/jtalks/jcommune/service/transactional/TransactionalTopicFetchServiceTest.java
+++ b/jcommune-service/src/test/java/org/jtalks/jcommune/service/transactional/TransactionalTopicFetchServiceTest.java
@@ -16,12 +16,14 @@ package org.jtalks.jcommune.service.transactional;
 
 import org.apache.commons.lang.StringUtils;
 import org.joda.time.DateTime;
+import org.jtalks.common.model.entity.Component;
 import org.jtalks.jcommune.model.dao.TopicDao;
 import org.jtalks.jcommune.model.dao.search.TopicSearchDao;
 import org.jtalks.jcommune.model.dto.PageRequest;
 import org.jtalks.jcommune.model.entity.Branch;
 import org.jtalks.jcommune.model.entity.JCUser;
 import org.jtalks.jcommune.model.entity.Topic;
+import org.jtalks.jcommune.service.ComponentService;
 import org.jtalks.jcommune.service.TopicFetchService;
 import org.jtalks.jcommune.service.UserService;
 import org.jtalks.jcommune.plugin.api.exceptions.NotFoundException;
@@ -59,11 +61,13 @@ public class TransactionalTopicFetchServiceTest {
     private TopicFetchService topicFetchService;
 
     private JCUser user;
+    @Mock
+    private ComponentService componentService;
 
     @BeforeMethod
     public void init(){
         initMocks(this);
-        topicFetchService = new TransactionalTopicFetchService(topicDao, userService, searchDao);
+        topicFetchService = new TransactionalTopicFetchService(topicDao, componentService, userService, searchDao);
         user = new JCUser("username", "email@mail.com", "password");
         when(userService.getCurrentUser()).thenReturn(user);
     }
@@ -169,8 +173,16 @@ public class TransactionalTopicFetchServiceTest {
         };
     }
 
+    private Component setupComponentMock() {
+        Component component = new Component();
+        component.setId(1L);
+        when(componentService.getComponentOfForum()).thenReturn(component);
+        return component;
+    }
+
     @Test
     public void testRebuildIndex() {
+        setupComponentMock();
         topicFetchService.rebuildSearchIndex();
 
         Mockito.verify(searchDao).rebuildIndex();

--- a/jcommune-view/jcommune-web-controller/src/test/java/org/jtalks/jcommune/web/controller/TopicSearchControllerTest.java
+++ b/jcommune-view/jcommune-web-controller/src/test/java/org/jtalks/jcommune/web/controller/TopicSearchControllerTest.java
@@ -45,8 +45,8 @@ public class TopicSearchControllerTest {
 	private TopicFetchService topicFetchService;
 	@Mock
 	private LastReadPostService lastReadPostService;
-    @Mock
-    private EntityToDtoConverter converter;
+	@Mock
+	private EntityToDtoConverter converter;
 
 	private TopicSearchController topicSearchController;
 

--- a/jcommune-view/jcommune-web-view/src/main/webapp/WEB-INF/security-context.xml
+++ b/jcommune-view/jcommune-web-view/src/main/webapp/WEB-INF/security-context.xml
@@ -86,7 +86,6 @@
     <security:intercept-url pattern="/pages/create/**" access="isAuthenticated()"/>
 
     <security:intercept-url pattern="/poll/**" access="isAuthenticated()"/>
-    <security:intercept-url pattern="/search/index/rebuild" access="hasIpAddress('127.0.0.1')"/>
     <security:intercept-url pattern="/configuration/*" access="isAuthenticated()"/>
 
     <security:intercept-url pattern="/recent/forum/markread" access="isAuthenticated()"/>

--- a/jcommune-view/jcommune-web-view/src/test/java/org/jtalks/jcommune/test/TopicSearchControllerTest.groovy
+++ b/jcommune-view/jcommune-web-view/src/test/java/org/jtalks/jcommune/test/TopicSearchControllerTest.groovy
@@ -1,0 +1,73 @@
+/**
+ * Copyright (C) 2011  JTalks.org Team
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+package org.jtalks.jcommune.test
+
+import org.jtalks.jcommune.test.model.User
+import org.jtalks.jcommune.test.service.ComponentService
+import org.jtalks.jcommune.test.service.GroupsService
+import org.jtalks.jcommune.test.utils.Users
+import org.jtalks.jcommune.web.controller.TopicSearchController
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.mock.web.MockHttpSession
+import org.springframework.test.context.ContextConfiguration
+import org.springframework.test.context.transaction.TransactionConfiguration
+import org.springframework.test.context.web.WebAppConfiguration
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.MvcResult
+import org.springframework.transaction.annotation.Transactional
+import spock.lang.Specification
+
+import javax.servlet.http.HttpSession
+
+import static org.jtalks.jcommune.test.utils.assertions.Assert.assertView
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
+
+/**
+ * The security test for {@link TopicSearchController}
+ * @author Evgeniy Cheban
+ */
+@WebAppConfiguration
+@ContextConfiguration(locations = 'classpath:/org/jtalks/jcommune/web/view/test-configuration.xml')
+@TransactionConfiguration(transactionManager = 'transactionManager', defaultRollback = true)
+@Transactional
+class TopicSearchControllerTest extends Specification {
+    @Autowired Users users;
+    @Autowired MockMvc mockMvc;
+    @Autowired ComponentService componentService;
+    @Autowired GroupsService groupsService;
+
+    def setup() {
+        groupsService.create();
+    }
+
+    def 'must not be able to send GET request to indexing data from database'() {
+        given: 'User created without admin permissions'
+            def user = new User();
+            users.created(user);
+            def session = users.signIn(user);
+        when: 'send GET request to indexing data from database'
+           MvcResult mvcResult = rebuildIndexes(session);
+        then: 'redirect to 403 error page'
+           assertView(mvcResult, "redirect:/errors/403");
+    }
+
+    def rebuildIndexes(HttpSession session) {
+        componentService.createForumComponent();
+        def result = mockMvc.perform(get('/search/index/rebuild')
+                .session(session as MockHttpSession))
+                .andReturn();
+        return result;
+    }
+}


### PR DESCRIPTION
- Added componentService in TransactionalTopicFetchService to checking user permissions
on the route: /search/index/rebuild.

- Added groovy security test which demonstrate that user without admin permissions
can't send GET request on this route, response status will be 403 and /errors/403 view
will be displayed.

- Fixed TransactionalTopicFetchServiceTest after made changes in TransactionalTopicFetchService.

- Fixed code format in TopicSearchControllerTest for GitHub.