### PR TITLE
JC-2342_PrivateMessageDraftValidationFix

### DIFF
--- a/jcommune-service/src/main/java/org/jtalks/jcommune/service/transactional/TransactionalPrivateMessageService.java
+++ b/jcommune-service/src/main/java/org/jtalks/jcommune/service/transactional/TransactionalPrivateMessageService.java
@@ -149,9 +149,16 @@ public class TransactionalPrivateMessageService
     @Override
     @PreAuthorize("hasPermission(#userFrom.id, 'USER', 'ProfilePermission.SEND_PRIVATE_MESSAGES')")
     public void saveDraft(long id, JCUser userTo, String title, String body, JCUser userFrom) {
-        PrivateMessage pm = new PrivateMessage(userTo, userFrom, title, body);
-        pm.setId(id);
-        pm.setStatus(PrivateMessageStatus.DRAFT);
+        PrivateMessage pm;
+        if (this.getDao().isExist(id)) {
+            pm = this.getDao().get(id);
+            pm.setUserTo(userTo);
+            pm.setTitle(title);
+            pm.setBody(body);
+        } else {
+            pm = new PrivateMessage(userTo, userFrom, title, body);
+            pm.setStatus(PrivateMessageStatus.DRAFT);
+        }
         this.getDao().saveOrUpdate(pm);
 
         JCUser user = userService.getCurrentUser();

--- a/jcommune-view/jcommune-web-controller/pom.xml
+++ b/jcommune-view/jcommune-web-controller/pom.xml
@@ -100,6 +100,10 @@
        <groupId>org.springframework.retry</groupId>
        <artifactId>spring-retry</artifactId>
     </dependency>
+    <dependency>
+      <groupId>io.qala.datagen</groupId>
+      <artifactId>qala-datagen</artifactId>
+    </dependency>
   </dependencies>
 
   <properties>

--- a/jcommune-view/jcommune-web-controller/src/main/java/org/jtalks/jcommune/web/dto/PrivateMessageDraftDto.java
+++ b/jcommune-view/jcommune-web-controller/src/main/java/org/jtalks/jcommune/web/dto/PrivateMessageDraftDto.java
@@ -14,10 +14,8 @@
  */
 package org.jtalks.jcommune.web.dto;
 
-import org.jtalks.jcommune.model.entity.JCUser;
 import org.jtalks.jcommune.model.entity.PrivateMessage;
 import org.jtalks.jcommune.web.validation.annotations.AtLeastOneNotEmpty;
-import org.jtalks.jcommune.web.validation.annotations.Exists;
 
 import javax.validation.constraints.Size;
 
@@ -36,8 +34,6 @@ public class PrivateMessageDraftDto {
     @Size(max = PrivateMessage.MAX_MESSAGE_LENGTH)
     private String body;
 
-    @Exists(entity = JCUser.class, field = "username", message = "{validation.wrong_recipient}", ignoreCase=true,
-            isNullableAllowed = true)
     private String recipient;
 
     private long id;


### PR DESCRIPTION
### Notes
Filling subject field with incorrect data in the private message form leads to Error 500 because it was no validation rules for this case. 

### Functionality Added or Changed
- Changed behaviour of application, when user insert incorrect data in the private message form
the error message will be shown with warning about wrong data instead of redirecting to _/drafts_.

### Bugs Fixed
- Saving Draft where Subject field has more than 255 symbols leads to Error 500.
- Saving previously deleted Draft (e.g. Draft is opened in separated tabs) leads to Error 500.