### PR TITLE
Update version of Flyway to 2.3.1

### DIFF
--- a/jcommune-model/src/main/resources/org/jtalks/jcommune/model/entity/Branch.hbm.xml
+++ b/jcommune-model/src/main/resources/org/jtalks/jcommune/model/entity/Branch.hbm.xml
@@ -72,8 +72,8 @@
 
   <query name="getAllowedSubscribersForBranch">
     <![CDATA[SELECT bs FROM org.jtalks.jcommune.model.entity.Branch branch JOIN branch.subscribers bs JOIN bs.groups bsg WHERE branch = (:branch) AND branch.id
-            not in (select v.branchId from org.jtalks.jcommune.model.entity.ViewTopicsBranches v where v.granting=0 and v.sid in elements(bsg.id))
-            AND branch.id in (select v.branchId from org.jtalks.jcommune.model.entity.ViewTopicsBranches v where v.granting=1 and v.sid in elements(bsg.id))]]>
+            not in (select v.branchId from org.jtalks.jcommune.model.entity.ViewTopicsBranches v where v.granting=0 and cast(v.sid as integer) in elements(bsg.id))
+            AND branch.id in (select v.branchId from org.jtalks.jcommune.model.entity.ViewTopicsBranches v where v.granting=1 and cast(v.sid as integer) in elements(bsg.id))]]>
   </query>
 
   <query name="getCountPostsInBranch">

--- a/jcommune-model/src/main/resources/org/jtalks/jcommune/model/entity/Topic.hbm.xml
+++ b/jcommune-model/src/main/resources/org/jtalks/jcommune/model/entity/Topic.hbm.xml
@@ -77,8 +77,8 @@ This might be tuned further in the future if the page size itself changes.-->
 
     <query name="getAllowedSubscribersForTopic">
         <![CDATA[SELECT ts FROM Topic topic JOIN topic.subscribers ts JOIN ts.groups tsg WHERE topic = (:topic) AND topic.branch.id
-            not in (select v.branchId from org.jtalks.jcommune.model.entity.ViewTopicsBranches v where v.granting=0 and v.sid in elements(tsg.id))
-            AND topic.branch.id in (select v.branchId from org.jtalks.jcommune.model.entity.ViewTopicsBranches v where v.granting=1 and v.sid in elements(tsg.id))]]>
+            not in (select v.branchId from org.jtalks.jcommune.model.entity.ViewTopicsBranches v where v.granting=0 and cast(v.sid as integer) in elements(tsg.id))
+            AND topic.branch.id in (select v.branchId from org.jtalks.jcommune.model.entity.ViewTopicsBranches v where v.granting=1 and cast(v.sid as integer) in elements(tsg.id))]]>
     </query>
 
     <query name="getCountTopicsInBranch">

--- a/jcommune-model/src/main/resources/org/jtalks/jcommune/model/entity/applicationContext-dao.xml
+++ b/jcommune-model/src/main/resources/org/jtalks/jcommune/model/entity/applicationContext-dao.xml
@@ -267,36 +267,19 @@
 
   <bean class="org.jtalks.jcommune.model.utils.PersistenceCleanupContextShutdownHook" destroy-method="dispose"/>
 
-  <!-- Migrations, todo: 4 beans - that's weird, Ticket has been left for common to move init to one method -->
-
-  <bean id="flyway_common_init" class="org.jtalks.common.util.FlywayWrapper"
-        init-method="smartInit">
+  <bean id="flyway_common" class="org.jtalks.common.util.FlywayWrapper" init-method="migrate">
     <property name="dataSource" ref="dataSource"/>
+    <property name="locations" value="org.jtalks.common.migrations"/>
     <property name="table" value="common_schema_version"/>
-    <property name="enabled" value="${migrations_enabled}"/>
-  </bean>
-  <bean id="flyway_common" class="org.jtalks.common.util.FlywayWrapper"
-        init-method="migrate"
-        depends-on="flyway_common_init">
-    <property name="dataSource" ref="dataSource"/>
-    <property name="basePackage" value="org.jtalks.common.migrations"/>
-    <property name="baseDir" value="/org/jtalks/common/migrations"/>
-    <property name="table" value="common_schema_version"/>
-    <property name="enabled" value="${migrations_enabled}"/>
-  </bean>
-  <bean id="flyway_jcommune_init" class="org.jtalks.common.util.FlywayWrapper"
-        init-method="smartInit"
-        depends-on="flyway_common">
-    <property name="dataSource" ref="dataSource"/>
-    <property name="table" value="jcommune_schema_version"/>
     <property name="enabled" value="${migrations_enabled}"/>
   </bean>
   <bean id="flyway_jcommune" class="org.jtalks.common.util.FlywayWrapper"
         init-method="migrate"
-        depends-on="flyway_jcommune_init">
+        depends-on="flyway_common">
     <property name="dataSource" ref="dataSource"/>
-    <property name="basePackage" value="org.jtalks.jcommune.migrations"/>
-    <property name="baseDir" value="/org/jtalks/jcommune/migrations"/>
+    <property name="initOnMigrate" value="true"/>
+    <property name="initVersion" value="0"/>
+    <property name="locations" value="org.jtalks.jcommune.migrations"/>
     <property name="table" value="jcommune_schema_version"/>
     <property name="enabled" value="${migrations_enabled}"/>
   </bean>

--- a/jcommune-view/jcommune-web-view/src/test/resources/org/jtalks/jcommune/web/view/test-configuration.xml
+++ b/jcommune-view/jcommune-web-view/src/test/resources/org/jtalks/jcommune/web/view/test-configuration.xml
@@ -51,17 +51,11 @@
     <constructor-arg index="0" ref="testFilters"/>
   </bean>
   <!--We don't use FlywayWrapper here because we don't need to disable migrations and also FlywayWrapper is MySQL-oriented-->
-  <bean id="flyway_jcommune_init" class="com.googlecode.flyway.core.Flyway"
-        init-method="init">
-    <property name="dataSource" ref="dataSource"/>
-    <property name="table" value="jcommune_schema_version"/>
-  </bean>
   <bean id="flyway_jcommune" class="com.googlecode.flyway.core.Flyway"
-        init-method="migrate"
-        depends-on="flyway_jcommune_init">
+        init-method="migrate">
     <property name="dataSource" ref="dataSource"/>
-    <property name="basePackage" value="org.jtalks.jcommune.migrations/test"/>
-    <property name="baseDir" value="/org/jtalks/jcommune/migrations/test"/>
+    <property name="initOnMigrate" value="true" />
+    <property name="locations" value="org.jtalks.jcommune.migrations/test"/>
     <property name="table" value="jcommune_schema_version"/>
   </bean>
 

--- a/pom.xml
+++ b/pom.xml
@@ -281,7 +281,7 @@
       <dependency>
         <groupId>org.hsqldb</groupId>
         <artifactId>hsqldb</artifactId>
-        <version>2.2.4</version>
+        <version>2.3.3</version>
         <scope>test</scope>
       </dependency>
       <dependency>
@@ -341,7 +341,7 @@
       <dependency>
         <groupId>com.googlecode.flyway</groupId>
         <artifactId>flyway-core</artifactId>
-        <version>1.4.2</version>
+        <version>2.3.1</version>
       </dependency>
       <dependency>
         <groupId>commons-beanutils</groupId>


### PR DESCRIPTION
Interim update of the Flyway for subsequent updates to version 4.0.
Optimized Flyway beans in application Context.

Change version of HSQLDB to 2.3.3 for test usage.
Used explicit type conversion in Topic and Branch entities because
auto casting behaviour has become more strict in HSQLDB.