### PR TITLE
fixed illegal mix of collations

### DIFF
--- a/jcommune-model/src/main/resources/org/jtalks/jcommune/migrations/V65__Add_admin_user.sql
+++ b/jcommune-model/src/main/resources/org/jtalks/jcommune/migrations/V65__Add_admin_user.sql
@@ -1,5 +1,9 @@
--- SET NAMES used to avoid Illegal mix of collations error when '=' operator is called
-SET NAMES 'utf8mb4' COLLATE 'utf8mb4_unicode_ci';
+-- vars that have different types of collation can not be compared by '=',
+-- that's why we need to set connection collation the same as database collation
+-- in spite of server configuration.
+SET @default_collation_connection = @@collation_connection;
+SET @@collation_connection = @@collation_database;
+
 set @adminUserName := 'admin';
 set @adminPassword := 'admin';
 set @adminGroupName := 'Administrators';
@@ -101,3 +105,6 @@ set @ace_order := (case when  @ace_order_max is null then 0 else @ace_order_max 
 insert ignore into acl_entry (acl_object_identity, sid, ace_order, mask, granting, audit_success, audit_failure)
   select @forum_acl_object_identity_id, @acl_sid_admin_group_id, @ace_order, @adminMask, 1, 0 , 0
   from dual;
+
+-- return collation_connection to a previous state.
+SET @@collation_connection = @default_collation_connection;

--- a/jcommune-model/src/main/resources/org/jtalks/jcommune/migrations/V6__Acl_Sid_encoding_fix.sql
+++ b/jcommune-model/src/main/resources/org/jtalks/jcommune/migrations/V6__Acl_Sid_encoding_fix.sql
@@ -1,2 +1,0 @@
-alter table `acl_sid` charset "utf8";
-alter table `acl_sid` modify `sid` varchar(100) charset "utf8" not null;

--- a/jcommune-model/src/main/resources/org/jtalks/jcommune/migrations/V6__Acl_encoding_fix.sql
+++ b/jcommune-model/src/main/resources/org/jtalks/jcommune/migrations/V6__Acl_encoding_fix.sql
@@ -1,0 +1,5 @@
+-- COLLATE DEFAULT means that we want to set TABLE collation the same as database.
+ALTER TABLE `acl_sid` CHAR SET 'UTF8' COLLATE DEFAULT;
+ALTER TABLE `acl_sid` MODIFY `sid` VARCHAR(100) not null;
+ALTER TABLE `acl_class` CHAR SET 'UTF8' COLLATE DEFAULT;
+ALTER TABLE `acl_class` MODIFY `class` VARCHAR(255)


### PR DESCRIPTION
- vars with different type of colllations can not be compared by '='
that's why need to set connection collation the same as database collation
in spite of server configuration.