### PR TITLE
Modify gatling scenarios.

### DIFF
--- a/jcommune-performance-tests/README.md
+++ b/jcommune-performance-tests/README.md
@@ -6,19 +6,13 @@
 2. Configure pom.xml
     ```
     <configuration>
-        <runMultipleSimulations>false</runMultipleSimulations> (1)
+        <runMultipleSimulations>true</runMultipleSimulations> (1)
         <simulationClass>org.jtalks.jcommune.performance.tests.OpenTopicPage</simulationClass> (2)
-        <jvmArgs>
-          <jvmArg>-Durl=http://performance.jtalks.org</jvmArg> (3)
-          <jvmArg>-Dport=</jvmArg> (4)
-          <jvmArg>-DurlPath=/jcommune</jvmArg> (5)
-        </jvmArgs>
     </configuration>
-    
+
+    Choose one:
     (1) set <runMultipleSimulations> **true** if you want to run all simulations sequentially.
     (2) choose specific simulation to run
-    (3) your application server url
-    (4) port to connect (can be empty if :80 used)
-    (5) path to your applcation (if needed)
-3. Run simulations with maven: mvn test.
-4. Result charts will be placed in "target" folder in your project root folder.
+3. Pass your server address as argument to Maven: -Dperformance.url=http://yourserveraddress.com otherwise http://performance.jtalks.org/jcommune will be taken.
+4. Run simulations with maven: mvn test -Dperformance.url=http://yourserveraddress.com.
+5. Result charts will be placed in "target" folder in your project root folder.

--- a/jcommune-performance-tests/pom.xml
+++ b/jcommune-performance-tests/pom.xml
@@ -123,13 +123,7 @@
         <artifactId>gatling-maven-plugin</artifactId>
         <version>${gatling-maven-plugin.version}</version>
         <configuration>
-          <runMultipleSimulations>false</runMultipleSimulations>
-          <simulationClass>org.jtalks.jcommune.performance.tests.OpenTopicPage</simulationClass>
-          <jvmArgs>
-            <jvmArg>-Durl=http://performance.jtalks.org</jvmArg>
-            <jvmArg>-Dport=</jvmArg>
-            <jvmArg>-DurlPath=/jcommune</jvmArg>
-          </jvmArgs>
+          <runMultipleSimulations>true</runMultipleSimulations>
         </configuration>
         <executions>
           <execution>

--- a/jcommune-performance-tests/src/test/scala/org/jtalks/jcommune/performance/model/User.scala
+++ b/jcommune-performance-tests/src/test/scala/org/jtalks/jcommune/performance/model/User.scala
@@ -12,20 +12,6 @@
  * License along with this library; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
  */
-/**
-  * Copyright (C) 2011  JTalks.org Team
-  * This library is free software; you can redistribute it and/or
-  * modify it under the terms of the GNU Lesser General Public
-  * License as published by the Free Software Foundation; either
-  * version 2.1 of the License, or (at your option) any later version.
-  * This library is distributed in the hope that it will be useful,
-  * but WITHOUT ANY WARRANTY; without even the implied warranty of
-  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-  * Lesser General Public License for more details.
-  * You should have received a copy of the GNU Lesser General Public
-  * License along with this library; if not, write to the Free Software
-  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
-  */
 
 package org.jtalks.jcommune.performance.model
 
@@ -33,7 +19,7 @@ import io.gatling.core.Predef._
 import io.gatling.core.structure.ChainBuilder
 import io.gatling.http.Predef._
 import org.jtalks.jcommune.performance.model.User.Role.Role
-import org.jtalks.jcommune.performance.utils.ScnBuilder.urlPath
+
 /**
   * @author Oleg Tkachenko
   */
@@ -46,9 +32,10 @@ object User {
   }
 
   private val header = Map("Accept" -> "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8")
+  private val credentials = Array(Map("username" -> "admin", "password" -> "admin"))
 
   val performLogin = scenario("Perform Login")
-    .feed(csv("credentials.csv").circular)
+    .feed(credentials.circular)
       .exec(http("Perform Login (" + "${username}" + ")")
       .post("/login_ajax")
       .formParam("userName", "${username}")
@@ -58,7 +45,7 @@ object User {
 
   def openForumMainPage(role: Role): ChainBuilder = exec(http("Open main forum page (" + role + ")")
     .get("/")
-    .check(regex(urlPath + "/branches/([\\d]{1,4})").find(0).saveAs("branchId"))
+    .check(regex(".*/branches/([\\d]{1,4})").find(0).saveAs("branchId"))
     .headers(header)
     .check(status.is(200))
   )
@@ -66,23 +53,23 @@ object User {
   def openRecent(role: Role): ChainBuilder = exec(http("Open recent (" + role + ")")
     .get("/topics/recent")
     .headers(header)
-    .check(regex(urlPath + "/topics/([\\d]{1,6})").find(0).saveAs("topicId"))
+    .check(regex(".*/topics/([\\d]{1,6})").find(0).saveAs("topicId"))
     .check(status.is(200))
   )
 
   def openBranch(role: Role): ChainBuilder = {
     doIf("${branchId.exists()}") {
-      exec(http("Open branch (id: " + "${branchId}" + ") by (" + role + ")")
+      exec(http("Open branch (id: ${branchId}) by (" + role + ")")
         .get("/branches/${branchId}")
         .headers(header)
         .check(status.is(200))
-        .check(regex(urlPath + "/topics/([\\d]{1,6})").find(0).saveAs("topicId")))
+        .check(regex(".*/topics/([\\d]{1,6})").find(0).saveAs("topicId")))
     }
   }
 
   def openRandomTopic(role: Role): ChainBuilder = {
     doIf("${topicId.exists()}") {
-      exec(http("Open topic (id: " + "${topicId}" + ") by (" + role + ")")
+      exec(http("Open topic (id: ${topicId}) by (" + role + ")")
         .get("/topics/${topicId}")
         .headers(header)
         .check(status.in(200, 304)))

--- a/jcommune-performance-tests/src/test/scala/org/jtalks/jcommune/performance/tests/Login.scala
+++ b/jcommune-performance-tests/src/test/scala/org/jtalks/jcommune/performance/tests/Login.scala
@@ -12,20 +12,6 @@
  * License along with this library; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
  */
-/**
-  * Copyright (C) 2011  JTalks.org Team
-  * This library is free software; you can redistribute it and/or
-  * modify it under the terms of the GNU Lesser General Public
-  * License as published by the Free Software Foundation; either
-  * version 2.1 of the License, or (at your option) any later version.
-  * This library is distributed in the hope that it will be useful,
-  * but WITHOUT ANY WARRANTY; without even the implied warranty of
-  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-  * Lesser General Public License for more details.
-  * You should have received a copy of the GNU Lesser General Public
-  * License along with this library; if not, write to the Free Software
-  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
-  */
 
 package org.jtalks.jcommune.performance.tests
 

--- a/jcommune-performance-tests/src/test/scala/org/jtalks/jcommune/performance/tests/OpenRecentActivityPage.scala
+++ b/jcommune-performance-tests/src/test/scala/org/jtalks/jcommune/performance/tests/OpenRecentActivityPage.scala
@@ -12,20 +12,6 @@
  * License along with this library; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
  */
-/**
-  * Copyright (C) 2011  JTalks.org Team
-  * This library is free software; you can redistribute it and/or
-  * modify it under the terms of the GNU Lesser General Public
-  * License as published by the Free Software Foundation; either
-  * version 2.1 of the License, or (at your option) any later version.
-  * This library is distributed in the hope that it will be useful,
-  * but WITHOUT ANY WARRANTY; without even the implied warranty of
-  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-  * Lesser General Public License for more details.
-  * You should have received a copy of the GNU Lesser General Public
-  * License along with this library; if not, write to the Free Software
-  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
-  */
 
 package org.jtalks.jcommune.performance.tests
 

--- a/jcommune-performance-tests/src/test/scala/org/jtalks/jcommune/performance/utils/ScnBuilder.scala
+++ b/jcommune-performance-tests/src/test/scala/org/jtalks/jcommune/performance/utils/ScnBuilder.scala
@@ -12,20 +12,6 @@
  * License along with this library; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
  */
-/**
-  * Copyright (C) 2011  JTalks.org Team
-  * This library is free software; you can redistribute it and/or
-  * modify it under the terms of the GNU Lesser General Public
-  * License as published by the Free Software Foundation; either
-  * version 2.1 of the License, or (at your option) any later version.
-  * This library is distributed in the hope that it will be useful,
-  * but WITHOUT ANY WARRANTY; without even the implied warranty of
-  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-  * Lesser General Public License for more details.
-  * You should have received a copy of the GNU Lesser General Public
-  * License along with this library; if not, write to the Free Software
-  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
-  */
 
 package org.jtalks.jcommune.performance.utils
 
@@ -40,8 +26,10 @@ import org.jtalks.jcommune.performance.model.User._
 
 object ScnBuilder {
 
-  val urlPath: String = System.getProperty("urlPath")
-  val url: String = System.getProperty("url") + getPort + urlPath
+  val serverUrl: String = {
+    val url: String = System.getProperty("performance.url")
+    if (url == null) "http://performance.jtalks.org/jcommune" else url
+  }
 
   val scnPerformLogin: ScenarioBuilder = scenario("Perform Login").exec(performLogin)
 
@@ -89,15 +77,11 @@ object ScnBuilder {
   }
 
   val httpProtocol = http
-    .baseURL(url)
+    .baseURL(serverUrl)
     .acceptHeader("text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8")
     .doNotTrackHeader("1")
     .acceptLanguageHeader("en-US,en;q=0.5")
     .acceptEncodingHeader("gzip, deflate")
     .userAgentHeader("Mozilla/5.0 (Windows NT 5.1; rv:31.0) Gecko/20100101 Firefox/31.0")
 
-  private def getPort = {
-    val port: String = System.getProperty("port")
-    if (port == null) "" else ":" + port
-  }
 }


### PR DESCRIPTION
- removed configuration from pom.xml, now there is only one parameter -
  performance.url that should contain full url path to application server
  and should be passed as an argument to Maven.
- removed credentials.csv, now credential storage is a Map<paramName,
  param> in org.jtalks.jcommune.performance.model.User
- removed redundant string concatenations
- changed readme.md

TODO: add comments
