### PR TITLE
JC-2306 - mark topic as read by separate request

### DIFF
--- a/jcommune-model/src/main/java/org/jtalks/jcommune/model/entity/Topic.java
+++ b/jcommune-model/src/main/java/org/jtalks/jcommune/model/entity/Topic.java
@@ -22,6 +22,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import com.google.common.base.Optional;
 import org.apache.solr.analysis.LowerCaseFilterFactory;
 import org.apache.solr.analysis.SnowballPorterFilterFactory;
 import org.apache.solr.analysis.StandardFilterFactory;
@@ -765,5 +766,25 @@ public class Topic extends Entity implements SubscriptionAwareEntity {
             }
         }
         return count;
+    }
+
+    /**
+     * Makes URL to mark topic page as read.
+     * For anonymous user returns empty optional.
+     *
+     * @param user current user
+     * @param page page to mark as read
+     * @return Optional url string
+     */
+    public Optional<String> getMarkAsReadUrl(JCUser user, String page) {
+        if (user.isAnonymous()) {
+            return Optional.absent();
+        }
+        return Optional.of("{topicId}/page/{pageNum}/markread?userId={userId}&lastModified={lastModified}"
+                                       .replace("{topicId}", String.valueOf(getId()))
+                                       .replace("{pageNum}", page)
+                                       .replace("{userId}", String.valueOf(user.getId()))
+                                       .replace("{lastModified}", String.valueOf(getLastModificationPostDate().getMillis()))
+        );
     }
 }

--- a/jcommune-model/src/test/java/org/jtalks/jcommune/model/entity/TopicTest.java
+++ b/jcommune-model/src/test/java/org/jtalks/jcommune/model/entity/TopicTest.java
@@ -18,6 +18,7 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
 
+import com.google.common.base.Optional;
 import org.joda.time.DateTime;
 import org.testng.annotations.Test;
 
@@ -456,6 +457,41 @@ public class TopicTest {
         topic.setBranch(branch);
 
         assertEquals(topic.getUnsubscribeLinkForSubscribersOf(BranchSubClass.class), "/branches/1/unsubscribe");
+    }
+
+    @Test
+    public void markAsReadUrlIsEmptyForAnonymousUser() throws Exception {
+        Optional<String> markAsReadUrl = createTopic().getMarkAsReadUrl(new AnonymousUser(), "2");
+        assertFalse(markAsReadUrl.isPresent(), "URL should be absent for anonymous user");
+    }
+
+    @Test
+    public void markAsReadUrlPresentsForNonAnonymousUser() throws Exception {
+        Optional<String> markAsReadUrl = createTopic().getMarkAsReadUrl(new JCUser(), "2");
+        assertTrue(markAsReadUrl.isPresent(), "URL should be present for authorized user");
+    }
+
+    @Test
+    public void markAsReadUrlContainsTopicIdAndPageNumberInPath() throws Exception {
+        Optional<String> markAsReadUrl = createTopic().getMarkAsReadUrl(new JCUser(), "2");
+        String url = markAsReadUrl.get();
+        assertTrue(url.startsWith("0/page/2/markread"), "URL should contain topicId and page");
+    }
+
+    @Test
+    public void markAsReadUrlContainsUserIdAsQueryParams() throws Exception {
+        Optional<String> markAsReadUrl = createTopic().getMarkAsReadUrl(new JCUser(), "2");
+        String url = markAsReadUrl.get();
+        assertTrue(url.contains("userId=0"), "URL should have userId param");
+    }
+
+    @Test
+    public void markAsReadUrlContainsLastModifiedAsQueryParams() throws Exception {
+        Topic topic = createTopic();
+        DateTime lastModificationPostDate = topic.getLastModificationPostDate();
+        Optional<String> markAsReadUrl = topic.getMarkAsReadUrl(new JCUser(), "2");
+        String url = markAsReadUrl.get();
+        assertTrue(url.endsWith("lastModified=" + lastModificationPostDate.getMillis()), "URL should have lastModified param");
     }
 
 

--- a/jcommune-view/jcommune-web-controller/src/main/java/org/jtalks/jcommune/web/controller/TopicController.java
+++ b/jcommune-view/jcommune-web-controller/src/main/java/org/jtalks/jcommune/web/controller/TopicController.java
@@ -78,7 +78,6 @@ public class TopicController {
     private TopicDraftService topicDraftService;
     private PostService postService;
     private BranchService branchService;
-    private LastReadPostService lastReadPostService;
     private UserService userService;
     private BreadcrumbBuilder breadcrumbBuilder;
     private LocationService locationService;
@@ -107,7 +106,6 @@ public class TopicController {
      *                                 {@link org.jtalks.jcommune.model.entity.Post} entity
      * @param branchService            the object which provides actions on
      *                                 {@link org.jtalks.jcommune.model.entity.Branch} entity
-     * @param lastReadPostService      to perform post-related actions
      * @param userService              to determine the current user logged in
      * @param breadcrumbBuilder        to create Breadcrumbs for pages
      * @param locationService          to track user location on forum (what page he is viewing now)
@@ -118,7 +116,6 @@ public class TopicController {
     public TopicController(TopicModificationService topicModificationService,
                            PostService postService,
                            BranchService branchService,
-                           LastReadPostService lastReadPostService,
                            UserService userService,
                            BreadcrumbBuilder breadcrumbBuilder,
                            LocationService locationService,
@@ -130,7 +127,6 @@ public class TopicController {
         this.topicModificationService = topicModificationService;
         this.postService = postService;
         this.branchService = branchService;
-        this.lastReadPostService = lastReadPostService;
         this.userService = userService;
         this.breadcrumbBuilder = breadcrumbBuilder;
         this.locationService = locationService;
@@ -280,7 +276,6 @@ public class TopicController {
         if (draft != null) {
             postDto = PostDto.getDtoFor(draft);
         }
-        lastReadPostService.markTopicPageAsRead(topic, postsPage.getNumber());
         return new ModelAndView("topic/postList")
                 .addObject("viewList", locationService.getUsersViewing(topic))
                 .addObject("usersOnline", sessionRegistry.getAllPrincipals())
@@ -288,7 +283,8 @@ public class TopicController {
                 .addObject("topic", topic)
                 .addObject(POST_DTO, postDto)
                 .addObject("subscribed", topic.getSubscribers().contains(currentUser))
-                .addObject(BREADCRUMB_LIST, breadcrumbBuilder.getForumBreadcrumb(topic));
+                .addObject(BREADCRUMB_LIST, breadcrumbBuilder.getForumBreadcrumb(topic))
+                .addObject("markAsReadLink", topic.getMarkAsReadUrl(currentUser, page).orNull());
     }
 
     /**

--- a/jcommune-view/jcommune-web-controller/src/test/java/org/jtalks/jcommune/web/controller/ReadPostsControllerTest.java
+++ b/jcommune-view/jcommune-web-controller/src/test/java/org/jtalks/jcommune/web/controller/ReadPostsControllerTest.java
@@ -18,9 +18,11 @@ import static org.testng.Assert.assertEquals;
 
 
 import org.jtalks.jcommune.model.entity.Branch;
+import org.jtalks.jcommune.model.entity.Topic;
 import org.jtalks.jcommune.service.BranchService;
 import org.jtalks.jcommune.service.LastReadPostService;
 import org.jtalks.jcommune.plugin.api.exceptions.NotFoundException;
+import org.jtalks.jcommune.service.TopicFetchService;
 import org.mockito.Mock;
 import static org.mockito.MockitoAnnotations.initMocks;
 
@@ -42,6 +44,9 @@ public class ReadPostsControllerTest {
     private BranchService branchService;
     @Mock
     private LastReadPostService lastReadPostService;
+    @Mock
+    private TopicFetchService topicFetchService;
+
     private ReadPostsController controller;
     RetryTemplate retryTemplate;
     
@@ -50,7 +55,7 @@ public class ReadPostsControllerTest {
         initMocks(this);
         retryTemplate = new RetryTemplate();
         retryTemplate.setRetryPolicy(new NeverRetryPolicy());
-        controller = new ReadPostsController(branchService, lastReadPostService, retryTemplate);
+        controller = new ReadPostsController(branchService, lastReadPostService, retryTemplate, topicFetchService);
     }
     
     @Test
@@ -79,5 +84,13 @@ public class ReadPostsControllerTest {
         
         assertEquals(result, "redirect:/branches/" + String.valueOf(markedBranchId));
         verify(lastReadPostService).markAllTopicsAsRead(willBeMarkedBranch);
+    }
+
+    @Test
+    public void markTopicAsReadByIdShouldMarkItAsRead() throws NotFoundException {
+        Topic topicToRead = new Topic();
+        when(topicFetchService.get(1L)).thenReturn(topicToRead);
+        controller.markTopicPageAsReadById(1L, 10);
+        verify(lastReadPostService).markTopicPageAsRead(topicToRead, 10);
     }
 }

--- a/jcommune-view/jcommune-web-controller/src/test/java/org/jtalks/jcommune/web/controller/TopicControllerTest.java
+++ b/jcommune-view/jcommune-web-controller/src/test/java/org/jtalks/jcommune/web/controller/TopicControllerTest.java
@@ -86,8 +86,6 @@ public class TopicControllerTest {
     @Mock
     private SessionRegistry registry;
     @Mock
-    private LastReadPostService lastReadPostService;
-    @Mock
     private EntityToDtoConverter converter;
 
     private TopicController controller;
@@ -105,7 +103,6 @@ public class TopicControllerTest {
                 topicModificationService,
                 postService,
                 branchService,
-                lastReadPostService,
                 userService,
                 breadcrumbBuilder,
                 locationService,
@@ -155,7 +152,6 @@ public class TopicControllerTest {
         ModelAndView mav = controller.showTopicPage(request, TOPIC_ID, page);
 
         verify(topicFetchService).checkViewTopicPermission(topic.getBranch().getId());
-        verify(lastReadPostService).markTopicPageAsRead(topic, Integer.valueOf(page));
         //
         assertViewName(mav, "topic/postList");
         assertAndReturnModelAttributeOfType(mav, "postsPage", Page.class);
@@ -441,6 +437,17 @@ public class TopicControllerTest {
         controller.openTopic(TOPIC_ID);
 
         verify(topicModificationService).openTopic(topic);
+    }
+
+    @Test
+    public void pageContainLinkToMarkAsRead() throws NotFoundException {
+        String page = "1";
+        Topic topic = createTopic();
+        prepareViewTopicMocks(topic, page);
+
+        ModelAndView mav = controller.showTopicPage(mock(WebRequest.class), TOPIC_ID, page);
+
+        assertModelAttributeAvailable(mav, "markAsReadLink");
     }
 
     private Branch createBranch() {

--- a/jcommune-view/jcommune-web-view/src/main/webapp/WEB-INF/jsp/topic/postList.jsp
+++ b/jcommune-view/jcommune-web-view/src/main/webapp/WEB-INF/jsp/topic/postList.jsp
@@ -385,4 +385,7 @@ Without it we're likely to get lots of problems simulating HTTP DELETE via JS in
     Utils.focusFirstEl('#postBody');
   }
 </script>
+<c:if test="${markAsReadLink != null}">
+  <script type="text/javascript" src="${markAsReadLink}" defer></script>
+</c:if>
 </body>

--- a/jcommune-view/jcommune-web-view/src/main/webapp/WEB-INF/spring-dispatcher-servlet.xml
+++ b/jcommune-view/jcommune-web-view/src/main/webapp/WEB-INF/spring-dispatcher-servlet.xml
@@ -100,6 +100,12 @@
       <property name="useExpiresHeader" value="true"/>
       <property name="useCacheControlHeader" value="true"/>
       <property name="useCacheControlNoStore" value="true"/>
+      <property name="cacheMappings">
+        <props>
+          <!-- Allow caching for "mark page as read" requests -->
+          <prop key="/topics/*/page/*/markread">604800</prop>
+        </props>
+      </property>
     </bean>
     <!--Fills common data, required to render all the pages-->
     <bean id="userDataInterceptor" class="org.jtalks.jcommune.web.interceptors.UserDataInterceptor"/>

--- a/jcommune-view/jcommune-web-view/src/test/java/org/jtalks/jcommune/test/ReadPostsControllerTest.groovy
+++ b/jcommune-view/jcommune-web-view/src/test/java/org/jtalks/jcommune/test/ReadPostsControllerTest.groovy
@@ -1,0 +1,61 @@
+/**
+ * Copyright (C) 2011  JTalks.org Team
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+package org.jtalks.jcommune.test
+
+import org.jtalks.common.model.permissions.BranchPermission
+import org.jtalks.jcommune.test.model.User
+import org.jtalks.jcommune.test.service.GroupsService
+import org.jtalks.jcommune.test.utils.Branches
+import org.jtalks.jcommune.test.utils.Topics
+import org.jtalks.jcommune.test.utils.Users
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.test.context.ContextConfiguration
+import org.springframework.test.context.transaction.TransactionConfiguration
+import org.springframework.test.context.web.WebAppConfiguration
+import org.springframework.transaction.annotation.Transactional
+import spock.lang.Specification
+
+/**
+ * @author Pavel Vervenko
+ */
+@WebAppConfiguration
+@ContextConfiguration(locations = 'classpath:/org/jtalks/jcommune/web/view/test-configuration.xml')
+@TransactionConfiguration(transactionManager = "transactionManager", defaultRollback = true)
+@Transactional
+class ReadPostsControllerTest extends Specification {
+
+    @Autowired Users users;
+    @Autowired Topics topics;
+    @Autowired GroupsService groupsService
+    @Autowired Branches branches;
+
+    def setup() {
+        groupsService.create()
+    }
+
+    def 'must mark topic as read'() {
+        given: 'Topic created'
+            def branch = branches.created();
+            def user = new User();
+            users.created(user).withPermissionOn(branch, BranchPermission.VIEW_TOPICS);
+            def session = users.signIn(user);
+            def topic = topics.created(user, branch);
+        when: 'User access mark as read link'
+            topics.markAsRead(session, topic, 1);
+        then: 'Topic marked as read'
+            topics.isMarkedAsRead(user, topic);
+
+    }
+}

--- a/jcommune-view/jcommune-web-view/src/test/java/org/jtalks/jcommune/test/TopicControllerTest.groovy
+++ b/jcommune-view/jcommune-web-view/src/test/java/org/jtalks/jcommune/test/TopicControllerTest.groovy
@@ -29,6 +29,8 @@ import org.springframework.test.context.ContextConfiguration
 import org.springframework.test.context.transaction.TransactionConfiguration
 import org.springframework.test.context.web.WebAppConfiguration
 import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.MvcResult
+import org.springframework.test.web.servlet.ResultMatcher
 import org.springframework.transaction.annotation.Transactional
 import spock.lang.Specification
 
@@ -37,9 +39,11 @@ import javax.servlet.Filter
 import javax.servlet.http.HttpSession
 
 import static org.hamcrest.Matchers.is
+import static org.springframework.test.util.AssertionErrors.assertTrue
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
 
 /**
  * @author Mikhail Stryzhonok
@@ -79,7 +83,7 @@ class TopicControllerTest extends Specification {
                     .param("topic.title", "title")
                     .param("branchId", branch.id.toString()))
         then: 'User redirected to newly created topic'
-            result.andExpect(status().isMovedTemporarily()).andExpect(redirectedUrl("/topics/1"))
+            result.andExpect(status().isMovedTemporarily()).andExpect(redirectedUrlMatches("/topics/\\d"))
     }
 
     def 'Creation of draft topic should pass'() {
@@ -134,5 +138,13 @@ class TopicControllerTest extends Specification {
         then:
           result.andExpect(status().isOk())
                   .andExpect(jsonPath('$.status', is('SUCCESS')))
+    }
+
+    def ResultMatcher redirectedUrlMatches(String expectedUrl) {
+        return new ResultMatcher() {
+            public void match(MvcResult result) {
+                assertTrue("Redirected URL", result.getResponse().getRedirectedUrl().matches(expectedUrl))
+            }
+        };
     }
 }

--- a/jcommune-view/jcommune-web-view/src/test/java/org/jtalks/jcommune/test/utils/Topics.groovy
+++ b/jcommune-view/jcommune-web-view/src/test/java/org/jtalks/jcommune/test/utils/Topics.groovy
@@ -1,0 +1,63 @@
+/**
+ * Copyright (C) 2011  JTalks.org Team
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+package org.jtalks.jcommune.test.utils
+
+import org.jtalks.jcommune.model.dao.LastReadPostDao
+import org.jtalks.jcommune.model.dao.TopicDao
+import org.jtalks.jcommune.model.dao.UserDao
+import org.jtalks.jcommune.model.entity.Branch
+import org.jtalks.jcommune.model.entity.JCUser
+import org.jtalks.jcommune.model.entity.Post
+import org.jtalks.jcommune.model.entity.Topic
+import org.jtalks.jcommune.test.model.User
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.mock.web.MockHttpSession
+import org.springframework.test.web.servlet.MockMvc
+
+import javax.servlet.http.HttpSession
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
+
+/**
+ * @author Pavel Vervenko
+ */
+class Topics {
+    @Autowired TopicDao topicDao;
+    @Autowired UserDao userDao
+    @Autowired MockMvc mockMvc
+    @Autowired LastReadPostDao lastReadPostDao;
+
+    Topic created(User user, Branch branch) {
+        JCUser jcUser = userDao.getByEmail(user.email);
+        def topic = new Topic(jcUser, "title", "Discussion")
+        Post first = new Post(jcUser, "post text");
+        topic.setBranch(branch);
+        topic.addPost(first);
+        topicDao.saveOrUpdate(topic);
+        return topic;
+    }
+
+    def markAsRead(HttpSession session, Topic topic, int page) {
+         mockMvc.perform(get("/topics/${topic.id}/page/$page/markread")
+                 .session(session as MockHttpSession)
+         );
+    }
+
+    boolean isMarkedAsRead(User user, Topic topic) {
+        JCUser jcUser = userDao.getByEmail(user.email);
+        def post = lastReadPostDao.getLastReadPost(jcUser, topic);
+        return post != null;
+    }
+}

--- a/jcommune-view/jcommune-web-view/src/test/resources/org/jtalks/jcommune/web/view/test-configuration.xml
+++ b/jcommune-view/jcommune-web-view/src/test/resources/org/jtalks/jcommune/web/view/test-configuration.xml
@@ -43,6 +43,7 @@
 
   <bean class="org.jtalks.jcommune.test.utils.Branches"/>
   <bean class="org.jtalks.jcommune.test.utils.Groups"/>
+  <bean class="org.jtalks.jcommune.test.utils.Topics"/>
   <bean class="org.jtalks.jcommune.test.service.GroupsService"/>
   <bean class="org.jtalks.jcommune.test.service.ComponentService"/>
   <bean class="org.jtalks.jcommune.test.service.SectionService"/>


### PR DESCRIPTION
* removed "mark as read" functionality from the topic controller
* created separate request for marking topics as read
* added url invocation to the topic for authorized users
* enabled request caching for this url