### PR TITLE
Include performance tests module into reactor

### DIFF
--- a/jcommune-performance-tests/README.md
+++ b/jcommune-performance-tests/README.md
@@ -1,6 +1,7 @@
-#Gatling performance tests ##
+Gatling performance tests
+-------------------------
 
-##HOW TO ##
+# Running Performance Tests
 
 1. Run your application server used for testing.
 2. Configure pom.xml
@@ -13,6 +14,8 @@
     Choose one:
     (1) set <runMultipleSimulations> **true** if you want to run all simulations sequentially.
     (2) choose specific simulation to run
-3. Pass your server address as argument to Maven: -Dperformance.url=http://yourserveraddress.com otherwise http://performance.jtalks.org/jcommune will be taken.
-4. Run simulations with maven: mvn test -Dperformance.url=http://yourserveraddress.com.
+3. Pass your server address as argument to Maven: `-Dperformance.url=http://yourserveraddress.com` otherwise 
+`http://performance.jtalks.org/jcommune` will be taken.
+4. Run simulations with maven: 
+`mvn test -pl jcommune-performance-tests -Dperformance-test.skip=false -Dperformance.url=http://yourserveraddress.com`
 5. Result charts will be placed in "target" folder in your project root folder.

--- a/jcommune-performance-tests/pom.xml
+++ b/jcommune-performance-tests/pom.xml
@@ -6,20 +6,17 @@
   <parent>
     <artifactId>jcommune</artifactId>
     <groupId>org.jtalks.jcommune</groupId>
-    <version>3.9-SNAPSHOT</version>
+    <version>3.10-SNAPSHOT</version>
   </parent>
 
   <artifactId>jcommune-performance-tests</artifactId>
-  <name>${project.artifactId}</name>
-  <url>www.jtalks.org</url>
 
   <description>
     This module contains performance tests.
   </description>
 
   <properties>
-    <maven.compiler.source>1.8</maven.compiler.source>
-    <maven.compiler.target>1.8</maven.compiler.target>
+    <performance-test.skip>true</performance-test.skip>
     <scala.version>2.11.7</scala.version>
     <encoding>UTF-8</encoding>
     <gatling.version>2.2.2</gatling.version>
@@ -124,6 +121,7 @@
         <version>${gatling-maven-plugin.version}</version>
         <configuration>
           <runMultipleSimulations>true</runMultipleSimulations>
+          <skip>${performance-test.skip}</skip>
         </configuration>
         <executions>
           <execution>

--- a/pom.xml
+++ b/pom.xml
@@ -13,6 +13,7 @@
     <module>jcommune-view</module>
     <module>jcommune-plugins</module>
     <module>jcommune-plugin-api</module>
+    <module>jcommune-performance-tests</module>
   </modules>
 
   <dependencyManagement>


### PR DESCRIPTION
We didn't include Performance System Tests in the reactor because we
didn't want to run them when unit/component tests are run. But the
downside was that you can't run the performance tests without
previously installing the parent POM.

To have both problems solved - the module is added to the list of
modules, but `mvn test` won't invoke the actual tests until a special
flag is passed. Ultimately to run just the performance tests:
`mvn -pl jcommune-performance-tests -Dperformance-test.skip=false`