### PR TITLE
JC-2367 Edit user groups (Groovy tests)

### DIFF
--- a/jcommune-view/jcommune-web-view/src/test/java/org/jtalks/jcommune/test/model/GroupDto.groovy
+++ b/jcommune-view/jcommune-web-view/src/test/java/org/jtalks/jcommune/test/model/GroupDto.groovy
@@ -1,0 +1,25 @@
+/**
+ * Copyright (C) 2011  JTalks.org Team
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+package org.jtalks.jcommune.test.model
+
+/**
+ * @author Oleg Tkachenko
+ */
+class GroupDto {
+    Long id
+    String name
+    String description
+}

--- a/jcommune-view/jcommune-web-view/src/test/java/org/jtalks/jcommune/test/service/GroupsService.java
+++ b/jcommune-view/jcommune-web-view/src/test/java/org/jtalks/jcommune/test/service/GroupsService.java
@@ -16,11 +16,11 @@ package org.jtalks.jcommune.test.service;
 
 import org.jtalks.common.model.entity.Group;
 import org.jtalks.jcommune.model.dao.GroupDao;
-import org.jtalks.jcommune.service.security.AdministrationGroup;
 import org.springframework.beans.factory.annotation.Autowired;
-
 import java.util.ArrayList;
 import java.util.List;
+
+import static org.jtalks.jcommune.service.security.AdministrationGroup.*;
 
 /**
  * @author Mikhail Stryzhonok
@@ -31,9 +31,9 @@ public class GroupsService {
     private GroupDao groupDao;
 
     public void create() {
-        groupDao.saveOrUpdate(new Group(AdministrationGroup.ADMIN.getName()));
-        groupDao.saveOrUpdate(new Group(AdministrationGroup.BANNED_USER.getName()));
-        groupDao.saveOrUpdate(new Group(AdministrationGroup.USER.getName()));
+        groupDao.saveOrUpdate(new Group(ADMIN.getName()));
+        groupDao.saveOrUpdate(new Group(BANNED_USER.getName()));
+        groupDao.saveOrUpdate(new Group(USER.getName()));
     }
 
     public List<Long> getIdsByName(List<String> groups) {
@@ -46,5 +46,10 @@ public class GroupsService {
 
     public Long getIdByName(String groupName) {
         return groupDao.getGroupByName(groupName).getId();
+    }
+
+    public Long save(Group group){
+        groupDao.saveOrUpdate(group);
+        return getIdByName(group.getName());
     }
 }

--- a/jcommune-view/jcommune-web-view/src/test/java/org/jtalks/jcommune/test/utils/Users.groovy
+++ b/jcommune-view/jcommune-web-view/src/test/java/org/jtalks/jcommune/test/utils/Users.groovy
@@ -14,6 +14,7 @@
  */
 package org.jtalks.jcommune.test.utils
 
+import org.jtalks.common.model.entity.Component
 import org.jtalks.common.model.permissions.GeneralPermission
 import org.jtalks.common.service.security.SecurityContextHolderFacade
 import org.jtalks.jcommune.model.dao.GroupDao
@@ -199,9 +200,21 @@ abstract class Users {
         assertThat(userGroups, not(hasItem(group)))
     }
 
-    def signInAsAdmin() {
+    HttpSession signInAsAdmin() {
         def adminUser = new User()
         created(adminUser).withPermissionOn(componentService.createForumComponent(), GeneralPermission.ADMIN)
         signIn(adminUser)
+    }
+
+    HttpSession signInAsAdmin(Component forum) {
+        def adminUser = User.newInstance()
+        created(adminUser).withPermissionOn(forum, GeneralPermission.ADMIN)
+        signIn(adminUser)
+    }
+
+    HttpSession signInAsRegisteredUser(Component forum) {
+        def user = User.newInstance()
+        created(user).withPermissionOn(forum, GeneralPermission.READ)
+        signIn(user)
     }
 }

--- a/jcommune-view/jcommune-web-view/src/test/java/org/jtalks/jcommune/test/utils/assertions/Assert.groovy
+++ b/jcommune-view/jcommune-web-view/src/test/java/org/jtalks/jcommune/test/utils/assertions/Assert.groovy
@@ -19,6 +19,7 @@ import org.jtalks.jcommune.plugin.api.web.dto.json.JsonResponseStatus
 import org.jtalks.jcommune.test.utils.exceptions.ProcessingException
 import org.jtalks.jcommune.test.utils.exceptions.ValidationException
 import org.jtalks.jcommune.test.utils.exceptions.WrongResponseException
+import org.springframework.security.access.AccessDeniedException
 import org.springframework.test.web.servlet.MvcResult
 import org.springframework.validation.BindingResult
 
@@ -70,4 +71,8 @@ class Assert {
         }
     }
 
+    static def isAccessGranted(MvcResult mvcResult) {
+        def exception = mvcResult.getResolvedException()
+        if (exception != null && exception instanceof AccessDeniedException) throw exception
+    }
 }


### PR DESCRIPTION
- added Groovy tests for editing group method in AdministrationController

//Next steps
- realize method isEditable() //returns false if group.name is equal to one of the next group names: {"Administrators", "Registered Users", "Banned Users"}, otherwise  returns true.
- add constructor(long id, String name, String description, int count) to populate DTO right from HQL query.