### PR TITLE
Get rid of JGroups

### DIFF
--- a/jcommune-model/pom.xml
+++ b/jcommune-model/pom.xml
@@ -129,10 +129,6 @@
       <groupId>net.sf.ehcache</groupId>
       <artifactId>ehcache-core</artifactId>
     </dependency>
-    <dependency>
-      <groupId>net.sf.ehcache</groupId>
-      <artifactId>ehcache-jgroupsreplication</artifactId>
-    </dependency>
     <!--
         Used for cache monitoring. Has conflicts with used version of slf4j.
     -->

--- a/jcommune-model/src/main/resources/org/jtalks/jcommune/model/entity/ehcache.xml
+++ b/jcommune-model/src/main/resources/org/jtalks/jcommune/model/entity/ehcache.xml
@@ -20,13 +20,6 @@
     <!--Contains replicating caches which are synchronized between the application components-->
 
     <diskStore path="java.io.tmpdir"/>
-
-    <cacheManagerPeerProviderFactory class="net.sf.ehcache.distribution.jgroups.JGroupsCacheManagerPeerProviderFactory"
-                                     properties="connect=UDP(mcast_addr=235.0.0.1;mcast_port=45567;):PING:
-                    MERGE2:FD_SOCK:VERIFY_SUSPECT:pbcast.NAKACK:UNICAST:pbcast.STABLE:
-                    FRAG:pbcast.GMS"
-                                     propertySeparator="::"/>
-
     <!-- enable ehcache monitoring -->
 <!--     <cacheManagerPeerListenerFactory -->
 <!--         class="org.terracotta.ehcachedx.monitor.probe.ProbePeerListenerFactory" -->
@@ -57,26 +50,14 @@
 
     <cache name="org.jtalks.common.model.entity.Section.branches" maxElementsInMemory="100"
            eternal="true" overflowToDisk="false" statistics="true">
-        <cacheEventListenerFactory class="net.sf.ehcache.distribution.jgroups.JGroupsCacheReplicatorFactory"
-                                   properties="replicateAsynchronously=true, replicatePuts=false,
-                        replicateUpdates=true, replicateUpdatesViaCopy=false,
-                        replicateRemovals=true"/>
     </cache>
 
     <cache name="org.jtalks.common.model.entity.Group.users" maxElementsInMemory="100"
            eternal="true" overflowToDisk="false" statistics="true">
-        <cacheEventListenerFactory class="net.sf.ehcache.distribution.jgroups.JGroupsCacheReplicatorFactory"
-                                   properties="replicateAsynchronously=true, replicatePuts=false,
-                        replicateUpdates=true, replicateUpdatesViaCopy=false,
-                        replicateRemovals=true"/>
     </cache>
 
     <cache name="org.jtalks.common.model.entity.User.groups" maxElementsInMemory="100"
            eternal="true" overflowToDisk="false" statistics="true">
-        <cacheEventListenerFactory class="net.sf.ehcache.distribution.jgroups.JGroupsCacheReplicatorFactory"
-                                   properties="replicateAsynchronously=true, replicatePuts=false,
-                        replicateUpdates=true, replicateUpdatesViaCopy=false,
-                        replicateRemovals=true"/>
     </cache>
 
     <cache name="org.jtalks.EHCOMMON"
@@ -84,9 +65,5 @@
            eternal="true"
            overflowToDisk="false"
            statistics="true">
-        <cacheEventListenerFactory class="net.sf.ehcache.distribution.jgroups.JGroupsCacheReplicatorFactory"
-                                   properties="replicateAsynchronously=true, replicatePuts=false,
-                        replicateUpdates=true, replicateUpdatesViaCopy=false,
-                        replicateRemovals=true"/>
     </cache>
 </ehcache>

--- a/jcommune-service/pom.xml
+++ b/jcommune-service/pom.xml
@@ -82,10 +82,6 @@
       <artifactId>ehcache-core</artifactId>
     </dependency>
     <dependency>
-      <groupId>net.sf.ehcache</groupId>
-      <artifactId>ehcache-jgroupsreplication</artifactId>
-    </dependency>
-    <dependency>
       <groupId>org.hsqldb</groupId>
       <artifactId>hsqldb</artifactId>
     </dependency>

--- a/jcommune-view/jcommune-web-controller/src/test/java/org/jtalks/jcommune/web/controller/AdministrationControllerTest.java
+++ b/jcommune-view/jcommune-web-controller/src/test/java/org/jtalks/jcommune/web/controller/AdministrationControllerTest.java
@@ -49,13 +49,13 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpSession;
 import java.util.*;
 
-import static org.jgroups.util.Util.assertTrue;
 import static org.mockito.Mockito.*;
 import static org.mockito.MockitoAnnotations.initMocks;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.model;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNull;
+import static org.testng.AssertJUnit.assertTrue;
 
 /**
  * @author Andrei Alikov

--- a/jcommune-view/jcommune-web-controller/src/test/java/org/jtalks/jcommune/web/interceptors/LocalInterceptorTest.java
+++ b/jcommune-view/jcommune-web-controller/src/test/java/org/jtalks/jcommune/web/interceptors/LocalInterceptorTest.java
@@ -23,9 +23,9 @@ import org.testng.annotations.Test;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
-import static org.jgroups.util.Util.assertTrue;
 import static org.mockito.Mockito.*;
 import static org.mockito.MockitoAnnotations.initMocks;
+import static org.testng.Assert.assertTrue;
 
 /**
  * 

--- a/pom.xml
+++ b/pom.xml
@@ -232,11 +232,6 @@
         <version>2.4.3</version>
       </dependency>
       <dependency>
-        <groupId>net.sf.ehcache</groupId>
-        <artifactId>ehcache-jgroupsreplication</artifactId>
-        <version>1.5</version>
-      </dependency>
-      <dependency>
         <groupId>org.springframework.retry</groupId>
         <artifactId>spring-retry</artifactId>
         <version>1.1.2.RELEASE</version>


### PR DESCRIPTION
Since we do not need the functionality of Poulpe (except authentication), we
also do not need distributed cache anymore.