### PR TITLE
Fixed: smileys are displayed as rombuses in title of question and in comments to question

### DIFF
--- a/jcommune-plugins/pom.xml
+++ b/jcommune-plugins/pom.xml
@@ -68,6 +68,11 @@
         <artifactId>velocity-tools</artifactId>
         <version>2.0</version>
       </dependency>
+      <dependency>
+        <groupId>org.unbescape</groupId>
+        <artifactId>unbescape</artifactId>
+        <version>1.1.4.RELEASE</version>
+      </dependency>
 
       <!-- TestNG & Mockito -->
       <dependency>

--- a/jcommune-plugins/questions-n-answers-plugin/pom.xml
+++ b/jcommune-plugins/questions-n-answers-plugin/pom.xml
@@ -41,6 +41,10 @@
       <artifactId>velocity-tools</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.unbescape</groupId>
+      <artifactId>unbescape</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.springframework</groupId>
       <artifactId>spring-test</artifactId>
     </dependency>

--- a/jcommune-plugins/questions-n-answers-plugin/src/main/java/org/jtalks/jcommune/plugin/questionsandanswers/controller/QuestionsAndAnswersController.java
+++ b/jcommune-plugins/questions-n-answers-plugin/src/main/java/org/jtalks/jcommune/plugin/questionsandanswers/controller/QuestionsAndAnswersController.java
@@ -47,6 +47,7 @@ import org.springframework.ui.velocity.VelocityEngineUtils;
 import org.springframework.validation.BindingResult;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.servlet.LocaleResolver;
+import org.unbescape.html.HtmlEscape;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
@@ -81,6 +82,7 @@ public class QuestionsAndAnswersController implements ApplicationContextAware, P
     private static final String QUESTION = "question";
     private static final String POST_PAGE = "postPage";
     private static final String SUBSCRIBED = "subscribed";
+    private static final String HTML_ESCAPE = "HtmlEscape";
     private static final String CONVERTER = "converter";
     private static final String VIEW_LIST = "viewList";
     private static final String LIMIT_OF_POSTS_ATTRIBUTE = "postLimit";
@@ -211,6 +213,7 @@ public class QuestionsAndAnswersController implements ApplicationContextAware, P
         data.put(POST_PAGE, new PageImpl<>(getSortedPosts(topic.getPosts())));
         data.put(BREADCRUMB_LIST, breadcrumbBuilder.getForumBreadcrumb(topic));
         data.put(SUBSCRIBED, false);
+        data.put(HTML_ESCAPE, HtmlEscape.class);
         data.put(CONVERTER, BbToHtmlConverter.getInstance());
         data.put(VIEW_LIST, getLocationService().getUsersViewing(topic));
         data.put(POST_DTO, postDto);
@@ -275,6 +278,7 @@ public class QuestionsAndAnswersController implements ApplicationContextAware, P
         data.put(BREADCRUMB_LIST, breadcrumbBuilder.getForumBreadcrumb(topic));
         data.put(TOPIC_DTO, topicDto);
         data.put(EDIT_MODE, true);
+        data.put(HTML_ESCAPE, HtmlEscape.class);
         model.addAttribute(CONTENT, getMergedTemplate(engine, QUESTION_FORM_TEMPLATE_PATH, "UTF-8", data));
         return PLUGIN_VIEW_NAME;
     }
@@ -307,6 +311,7 @@ public class QuestionsAndAnswersController implements ApplicationContextAware, P
             data.put(TOPIC_DTO, topicDto);
             data.put(EDIT_MODE, true);
             data.put(RESULT, result);
+            data.put(HTML_ESCAPE, HtmlEscape.class);
             model.addAttribute(CONTENT, getMergedTemplate(engine, QUESTION_FORM_TEMPLATE_PATH, "UTF-8", data));
             return PLUGIN_VIEW_NAME;
 
@@ -336,6 +341,7 @@ public class QuestionsAndAnswersController implements ApplicationContextAware, P
         Map<String, Object> data = getDefaultModel(request);
         data.put(QEUSTION_TITLE, answer.getTopic().getTitle());
         data.put(POST_DTO, answerDto);
+        data.put(HTML_ESCAPE, HtmlEscape.class);
         model.addAttribute(CONTENT, getMergedTemplate(engine, ANSWER_FORM_TEMPLATE_PATH, "UTF-8", data));
         return PLUGIN_VIEW_NAME;
     }
@@ -364,6 +370,7 @@ public class QuestionsAndAnswersController implements ApplicationContextAware, P
             data.put(QEUSTION_TITLE, answer.getTopic().getTitle());
             data.put(POST_DTO, postDto);
             data.put(RESULT, result);
+            data.put(HTML_ESCAPE, HtmlEscape.class);
             model.addAttribute(CONTENT, getMergedTemplate(engine, ANSWER_FORM_TEMPLATE_PATH, "UTF-8", data));
             return PLUGIN_VIEW_NAME;
 

--- a/jcommune-plugins/questions-n-answers-plugin/src/main/resources/org/jtalks/jcommune/plugin/questionsandanswers/template/answerForm.vm
+++ b/jcommune-plugins/questions-n-answers-plugin/src/main/resources/org/jtalks/jcommune/plugin/questionsandanswers/template/answerForm.vm
@@ -16,10 +16,10 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 *#
 #parse("org/jtalks/jcommune/jcommune-plugin-api/web/templates/bbeditor.vm")
 <head>
-  <meta name="description" content="${esc.html(${questionTitle})}">
+  <meta name="description" content="${HtmlEscape.escapeHtml5(${questionTitle})}">
   <title>
     ${propertiesHolder.allPagesTitlePrefix}
-    ${esc.html(${questionTitle})} - ${messages.getString("label.tips.edit.answer")}
+    ${HtmlEscape.escapeHtml5(${questionTitle})} - ${messages.getString("label.tips.edit.answer")}
   </title>
 </head>
 <body>
@@ -31,7 +31,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
     <form action="${request.contextPath}/topics/question/post/${postDto.id}/edit"
           method="POST" id="postDto" class="well anti-multipost submit-form" enctype="multipart/form-data">
         <input type="hidden" name="topicId" value="${postDto.topicId}"/>
-      #bbeditor(${messages.getString("label.tips.edit.answer")} "" "${esc.html(${postDto.bodyText})}" "bodyText" true ${messages.getString("label.answer.placeholder")} ${result})
+      #bbeditor(${messages.getString("label.tips.edit.answer")} "" "${HtmlEscape.escapeHtml5(${postDto.bodyText})}" "bodyText" true ${messages.getString("label.answer.placeholder")} ${result})
     </form>
 
 

--- a/jcommune-plugins/questions-n-answers-plugin/src/main/resources/org/jtalks/jcommune/plugin/questionsandanswers/template/comments.vm
+++ b/jcommune-plugins/questions-n-answers-plugin/src/main/resources/org/jtalks/jcommune/plugin/questionsandanswers/template/comments.vm
@@ -57,10 +57,10 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
             <div class="cleared"></div>
           </div>
           <div class="comment-body">
-            <span id="body-$comment.id" class="comment-content">${esc.html($comment.body)}</span>
+            <span id="body-$comment.id" class="comment-content">${HtmlEscape.escapeHtml5($comment.body)}</span>
             <div id="edit-$comment.id" class="control-group edit" style="display: none">
                   <textarea id="editable-$comment.id" name="commentBody" class="comment-textarea edit-comment"
-                             rows="3">${esc.html($comment.body)}</textarea>
+                             rows="3">${HtmlEscape.escapeHtml5($comment.body)}</textarea>
                   <div class="comment-buttons-container">
                       <div class="pull-right">
                           <a class="btn btn-primary edit-submit" data-comment-id="$comment.id"><jcommune:message>label.save</jcommune:message></a>

--- a/jcommune-plugins/questions-n-answers-plugin/src/main/resources/org/jtalks/jcommune/plugin/questionsandanswers/template/question.vm
+++ b/jcommune-plugins/questions-n-answers-plugin/src/main/resources/org/jtalks/jcommune/plugin/questionsandanswers/template/question.vm
@@ -78,7 +78,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
   <script>#include("org/jtalks/jcommune/plugin/questionsandanswers/template/js/question.js")</script>
   <title>
     ${propertiesHolder.allPagesTitlePrefix}
-    ${esc.html(${question.title})}
+    ${HtmlEscape.escapeHtml5(${question.title})}
   </title>
 </head>
 <body>
@@ -86,7 +86,9 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 <div class="container">
   <div id="branch-header">
     <h1>
-      <a class="invisible-link" href="${request.contextPath}/topics/question/${question.id}">${esc.html(${question.title})}</a>
+      <a class="invisible-link" href="${request.contextPath}/topics/question/${question.id}">
+        ${HtmlEscape.escapeHtml5(${question.title})}
+      </a>
     </h1>
 
     <div id="right-block">
@@ -278,7 +280,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
     <form id="answerForm" action="${request.contextPath}/topics/question/${question.id}"
           method="POST" class='well anti-multipost submit-form $formVisibilityClass'>
       <form path="topicId"/>
-      #bbeditor(${messages.getString($labelAnswerType)} "" "${esc.html(${postDto.bodyText})}" "bodyText" true ${messages.getString("label.answer.placeholder")})
+      #bbeditor(${messages.getString($labelAnswerType)} "" "${HtmlEscape.escapeHtml5(${postDto.bodyText})}" "bodyText" true ${messages.getString("label.answer.placeholder")})
     </form>
     <div id="antiMultiAnswers" class="well $antiMultianswerBtnVisibilityClass">
       <button id="antiMultiAnswersBtn" class="btn btn-primary">${messages.getString($labelAnswerType)}</button>

--- a/jcommune-plugins/questions-n-answers-plugin/src/main/resources/org/jtalks/jcommune/plugin/questionsandanswers/template/questionForm.vm
+++ b/jcommune-plugins/questions-n-answers-plugin/src/main/resources/org/jtalks/jcommune/plugin/questionsandanswers/template/questionForm.vm
@@ -17,11 +17,11 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 #parse("org/jtalks/jcommune/jcommune-plugin-api/web/templates/breadcrumb.vm")
 #parse("org/jtalks/jcommune/jcommune-plugin-api/web/templates/bbeditor.vm")
 <head>
-  <meta name="description" content="${esc.html(${topicDto.topic.branch.name})}">
+  <meta name="description" content="${HtmlEscape.escapeHtml5(${topicDto.topic.branch.name})}">
   <title>
     ${propertiesHolder.allPagesTitlePrefix}
     #if(!${result.hasErrors()})
-      ${esc.html(${topicDto.topic.branch.name})} -
+      ${HtmlEscape.escapeHtml5(${topicDto.topic.branch.name})} -
     #end
     #if(${edit})
       ${messages.getString("label.tips.edit.question")}
@@ -56,11 +56,11 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
           <input name="topic.title" id="subject" type="text"  size="45"
             maxlength="255" tabindex="100"
             class="full-width script-confirm-unsaved" placeholder="${messages.getString("label.question")}"
-            value="${esc.html(${topicDto.topic.title})}"/>
+            value="${HtmlEscape.escapeHtml5(${topicDto.topic.title})}"/>
           #jtalksBinding(${result} "topic.title")
         </div>
       </div>
-      #bbeditor(${messages.getString("label.ask")} "" "${esc.html(${topicDto.bodyText})}" "bodyText" true ${messages.getString("label.question.details")} ${result})
+      #bbeditor(${messages.getString("label.ask")} "" "${HtmlEscape.escapeHtml5(${topicDto.bodyText})}" "bodyText" true ${messages.getString("label.question.details")} ${result})
     </form>
 
 

--- a/pom.xml
+++ b/pom.xml
@@ -443,6 +443,12 @@
         <artifactId>spring-data-commons-core</artifactId>
         <version>1.3.0.RELEASE</version>
       </dependency>
+      <!-- Library for html5 escaping. Needed to correct escaping strings that contain Emoji -->
+      <dependency>
+        <groupId>org.unbescape</groupId>
+        <artifactId>unbescape</artifactId>
+        <version>1.1.4.RELEASE</version>
+      </dependency>
       <dependency>
         <groupId>org.codehaus.groovy</groupId>
         <artifactId>groovy-all</artifactId>


### PR DESCRIPTION
JC-2350 Fixed: smileys (UTF-8) are displayed as rombuses in title
of the question

JC-2351 Fixed: smileys (UTF-8) are displayed as rombuses
in comments to the question

Fixed not correct escaping of Emoji in other elements of user
interface of QuestionsAndAnswers plugin.

To solve tasks used Unbescape Java library for correct escaping
strings that contain Emoji:  https://github.com/unbescape/unbescape

Next step: writing tests to check the correctness of text and title
in questions and answers.