### PR TITLE
JC-2351 Fixed: Smileys are displayed as rombuses in comments

### DIFF
--- a/jcommune-plugins/questions-n-answers-plugin/src/main/java/org/jtalks/jcommune/plugin/questionsandanswers/controller/QuestionsAndAnswersController.java
+++ b/jcommune-plugins/questions-n-answers-plugin/src/main/java/org/jtalks/jcommune/plugin/questionsandanswers/controller/QuestionsAndAnswersController.java
@@ -38,6 +38,8 @@ import org.jtalks.jcommune.plugin.api.web.velocity.tool.JodaDateTimeTool;
 import org.jtalks.jcommune.plugin.api.web.velocity.tool.PermissionTool;
 import org.jtalks.jcommune.plugin.questionsandanswers.QuestionsAndAnswersPlugin;
 import org.jtalks.jcommune.plugin.questionsandanswers.dto.CommentDto;
+import org.kefirsf.bb.EscapeXmlProcessorFactory;
+import org.kefirsf.bb.TextProcessor;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.ApplicationContextAware;
 import org.springframework.data.domain.PageImpl;
@@ -91,7 +93,11 @@ public class QuestionsAndAnswersController implements ApplicationContextAware, P
     private static final String QEUSTION_TITLE = "questionTitle";
     public static final String POST_ID = "postId";
     public static final String COMMENT_ID = "commentId";
+    private static final String HTML_ESCAPER = "htmlEscaper";
 
+    // custom processor is used for escaping of HTML because
+    // standard Velocity escaping utility not correct displays emoji.
+    private TextProcessor htmlEscaper = EscapeXmlProcessorFactory.getInstance().create();
 
     private BreadcrumbBuilder breadcrumbBuilder = new BreadcrumbBuilder();
 
@@ -212,6 +218,7 @@ public class QuestionsAndAnswersController implements ApplicationContextAware, P
         data.put(BREADCRUMB_LIST, breadcrumbBuilder.getForumBreadcrumb(topic));
         data.put(SUBSCRIBED, false);
         data.put(CONVERTER, BbToHtmlConverter.getInstance());
+        data.put(HTML_ESCAPER, htmlEscaper);
         data.put(VIEW_LIST, getLocationService().getUsersViewing(topic));
         data.put(POST_DTO, postDto);
         data.put(LIMIT_OF_POSTS_ATTRIBUTE, LIMIT_OF_POSTS_VALUE);

--- a/jcommune-plugins/questions-n-answers-plugin/src/main/resources/org/jtalks/jcommune/plugin/questionsandanswers/template/comments.vm
+++ b/jcommune-plugins/questions-n-answers-plugin/src/main/resources/org/jtalks/jcommune/plugin/questionsandanswers/template/comments.vm
@@ -57,10 +57,10 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
             <div class="cleared"></div>
           </div>
           <div class="comment-body">
-            <span id="body-$comment.id" class="comment-content">${esc.html($comment.body)}</span>
+            <span id="body-$comment.id" class="comment-content">${htmlEscaper.process($comment.body)}</span>
             <div id="edit-$comment.id" class="control-group edit" style="display: none">
                   <textarea id="editable-$comment.id" name="commentBody" class="comment-textarea edit-comment"
-                             rows="3">${esc.html($comment.body)}</textarea>
+                             rows="3">${htmlEscaper.process($comment.body)}</textarea>
                   <div class="comment-buttons-container">
                       <div class="pull-right">
                           <a class="btn btn-primary edit-submit" data-comment-id="$comment.id"><jcommune:message>label.save</jcommune:message></a>

--- a/jcommune-service/src/main/resources/kefirbb-strip-config.xml
+++ b/jcommune-service/src/main/resources/kefirbb-strip-config.xml
@@ -23,7 +23,7 @@ get XSS attacks.</p>-->
 <!--See more docs on official site: http://kefir-bb.sourceforge.net/-->
 <configuration xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                xmlns="http://kefirsf.org/kefirbb/schema"
-               xsi:schemaLocation="http://kefirsf.org/kefirbb/schema http://kefirsf.org/kefirbb/schema/kefirbb-1.0.xsd">
+               xsi:schemaLocation="http://kefirsf.org/kefirbb/schema http://kefirsf.org/kefirbb/schema/kefirbb-1.2.xsd">
     <!-- XML escape symbols -->
     <scope name="escapeXml">
         <code priority="100">

--- a/jcommune-service/src/main/resources/kefirbb.xml
+++ b/jcommune-service/src/main/resources/kefirbb.xml
@@ -23,7 +23,7 @@ get XSS attacks.</p>-->
 <!--See more docs on official site: http://kefir-bb.sourceforge.net/-->
 <configuration xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                xmlns="http://kefirsf.org/kefirbb/schema"
-               xsi:schemaLocation="http://kefirsf.org/kefirbb/schema http://kefirsf.org/kefirbb/schema/kefirbb-1.0.xsd">
+               xsi:schemaLocation="http://kefirsf.org/kefirbb/schema http://kefirsf.org/kefirbb/schema/kefirbb-1.2.xsd">
     <!-- XML escape symbols -->
     <scope name="escapeXml">
         <code priority="100">
@@ -252,12 +252,12 @@ get XSS attacks.</p>-->
     <!-- Insert image -->
     <code name="img1" priority="2">
         <pattern ignoreCase="true">[img]<var name="addr" regex=".*"/>[/img]</pattern>
-        <template><![CDATA[<a title="" href="]]><var name="addr"/><![CDATA[" class="pretty-photo"><img class="thumbnail" alt="" src="]]><var name="addr"/><![CDATA[" onError="imgError(this)" /></a>]]></template>
+        <template>&lt;a title="" href="<var name="addr"/>" class="pretty-photo"&gt;&lt;img class="thumbnail" alt="" src="<var name="addr"/>" onError="imgError(this)" /&gt;&lt;/a&gt;</template>
     </code>
 
     <code name="img2" priority="2">
         <pattern ignoreCase="true">[img][/img]</pattern>
-        <template><![CDATA[<a title="" href="/a" class="pretty-photo"><img class="thumbnail-default" alt="" src="/a" onError="imgError(this)" /></a>]]></template>
+        <template>&lt;a title="" href="/a" class="pretty-photo"&gt;&lt;img class="thumbnail-default" alt="" src="/a" onError="imgError(this)" /&gt;&lt;/a&gt;</template>
     </code>
 
     <!-- Links. http, https, mailto protocols -->
@@ -311,12 +311,12 @@ get XSS attacks.</p>-->
     <!-- Quote block -->
     <code name="quote">
         <pattern ignoreCase="true">[quote]<var inherit="true"/>[/quote]</pattern>
-        <template><![CDATA[<div class="quote bb_quote_container"><span class="bb_quote_title">Quote:</span><div class='bb_quote_content'>]]><var/><![CDATA[</div></div>]]></template>
+        <template>&lt;div class="quote bb_quote_container"&gt;&lt;span class="bb_quote_title"&gt;Quote:&lt;/span&gt;&lt;div class='bb_quote_content'&gt;<var/>&lt;/div&gt;&lt;/div&gt;</template>
     </code>
 
     <code name="quote_named">
         <pattern ignoreCase="true">[quote="<var name="author" inherit="true"/>"]<var name="content" inherit="true"/>[/quote]</pattern>
-        <template><![CDATA[<div class="quote bb_quote_container"><span class="bb_quote_title">]]><var name="author"/><![CDATA[:</span><div class='bb_quote_content'>]]><var name="content"/><![CDATA[</div></div>]]></template>
+        <template>&lt;div class="quote bb_quote_container"&gt;&lt;span class="bb_quote_title"&gt;<var name="author"/>:&lt;/span&gt;&lt;div class='bb_quote_content'&gt;<var name="content"/>&lt;/div&gt;&lt;/div&gt;</template>
     </code>
 
     <!-- Code block -->
@@ -328,7 +328,7 @@ get XSS attacks.</p>-->
     <!-- Offtopic block -->
     <code name="offtop">
         <pattern ignoreCase="true">[offtop]<var scope="basic"/>[/offtop]</pattern>
-        <template><![CDATA[<div class="offtop"><p>]]><var/><![CDATA[</p></div>]]></template>
+        <template>&lt;div class="offtop"&gt;&lt;p&gt;<var/>&lt;/p&gt;&lt;/div&gt;</template>
     </code>
 
     <!-- Simple table -->

--- a/pom.xml
+++ b/pom.xml
@@ -358,7 +358,7 @@
       <dependency>
         <groupId>org.kefirsf</groupId>
         <artifactId>kefirbb</artifactId>
-        <version>1.0</version>
+        <version>1.5</version>
       </dependency>
 
       <!--Mail-->


### PR DESCRIPTION
Using custom processor for escaping of HTML because standard Velocity
escaping utility not correct displays emoji.

Changed version of kefirbb library to 1.5