### PR TITLE
JC-963 An incorrect message appears when a user performs the 'Remove …

### DIFF
--- a/jcommune-service/src/main/java/org/jtalks/jcommune/service/nontransactional/ImageService.java
+++ b/jcommune-service/src/main/java/org/jtalks/jcommune/service/nontransactional/ImageService.java
@@ -48,12 +48,11 @@ public class ImageService {
      * user-friendly string with all valid image types
      */
     private static final String VALID_IMAGE_EXTENSIONS = "*.jpeg, *.jpg, *.gif, *.png, *.ico";
-
+    private static final Logger LOGGER = LoggerFactory.getLogger(ImageService.class);
     private ImageConverter imageConverter;
     private Base64Wrapper base64Wrapper;
     private JCommuneProperty imageSizeProperty;
     private String defaultImagePath;
-    private static final Logger LOGGER = LoggerFactory.getLogger(ImageService.class);
 
     /**
      * Create ImageService instance
@@ -88,6 +87,23 @@ public class ImageService {
             LOGGER.error("Failed to load default image", e);
         }
         return result;
+    }
+
+    /**
+     * Check image user avatar
+     *
+     * @param avatar image for compare with default image
+     * @return true if avatar image default
+     */
+    public boolean isDefaultImage(byte[] avatar) {
+        boolean isDefaultImage = false;
+        try {
+            isDefaultImage = Arrays.equals(getDefaultImage(), avatar) ? true
+                    : preProcessAndEncodeInString64(getDefaultImage()).equals(imageConverter.prepareHtmlImgSrc(avatar));
+        } catch (ImageProcessException e) {
+            LOGGER.error("Can't convert default image user avatar", e);
+        }
+        return isDefaultImage;
     }
 
     /**

--- a/jcommune-view/jcommune-web-controller/src/main/java/org/jtalks/jcommune/web/controller/UserProfileController.java
+++ b/jcommune-view/jcommune-web-controller/src/main/java/org/jtalks/jcommune/web/controller/UserProfileController.java
@@ -245,6 +245,7 @@ public class UserProfileController {
     private void setAvatarToUserProfileView(EditUserProfileDto editUserProfileDto, JCUser user) {
         byte[] avatar = user.getAvatar();
         editUserProfileDto.setAvatar(imageConverter.prepareHtmlImgSrc(avatar));
+        editUserProfileDto.setDefaultAvatarFlag(imageService.isDefaultImage(avatar));
     }
 
     /**

--- a/jcommune-view/jcommune-web-controller/src/main/java/org/jtalks/jcommune/web/dto/EditUserProfileDto.java
+++ b/jcommune-view/jcommune-web-controller/src/main/java/org/jtalks/jcommune/web/dto/EditUserProfileDto.java
@@ -39,6 +39,7 @@ public class EditUserProfileDto {
     private long userId;
     private String username;
     private String avatar;
+    private boolean defaultAvatarFlag;
     private Long userProfileVersion;
 
     @Valid
@@ -52,6 +53,14 @@ public class EditUserProfileDto {
 
     @Valid
     private UserContactsDto userContactsDto;
+
+    public boolean isDefaultAvatarFlag() {
+        return defaultAvatarFlag;
+    }
+
+    public void setDefaultAvatarFlag(Boolean defaultAvatarFlag) {
+        this.defaultAvatarFlag = defaultAvatarFlag;
+    }
 
     /**
      * Create instance with UserProfileDto. All required fields retrieved from JCUser.

--- a/jcommune-view/jcommune-web-view/src/main/webapp/WEB-INF/jsp/editUserProfile.jsp
+++ b/jcommune-view/jcommune-web-view/src/main/webapp/WEB-INF/jsp/editUserProfile.jsp
@@ -32,10 +32,12 @@
         <i class="icon-picture"></i>
         <spring:message code="label.avatar.load"/>
       </a>
+    <c:if test="${!editedUser.avatar.isEmpty() && !editedUser.defaultAvatarFlag}">
       <a id="removeAvatar" href="#" class="btn btn-mini btn-danger space-left-big-nf"
          title="<spring:message code="label.avatar.remove" />">
         <i class="icon-remove icon-white"></i>
       </a>
+    </c:if>
     </div>
   </c:if>
 


### PR DESCRIPTION
…avatar' action for an empty avatar.

Added disable button "Remove avatar", if the avatar default.
Checks 2 cases:
 1. when a default avatar has never changed.
 2. when a user downloads your avatar, but then deleted it and it changed
   to the default avatar.
Avatars in these cases differ by their size, etc.