### PR TITLE
clean up thread-locals

### DIFF
--- a/jcommune-service/src/main/java/org/jtalks/jcommune/service/security/SecurityService.java
+++ b/jcommune-service/src/main/java/org/jtalks/jcommune/service/security/SecurityService.java
@@ -43,7 +43,7 @@ public class SecurityService implements UserDetailsService {
     private final AclManager aclManager;
     private final AclBuilders aclBuilders = new AclBuilders();
     private final SecurityContextFacade securityContextFacade;
-    private ThreadLocal<JCUser> cachedUser = new ThreadLocal<>();
+    private final static ThreadLocal<JCUser> CACHED_USER = new ThreadLocal<>();
 
     /**
      * Constructor creates an instance of service.
@@ -162,10 +162,10 @@ public class SecurityService implements UserDetailsService {
     }
 
     private JCUser updateCacheAndGet(long principalId){
-        JCUser cached = cachedUser.get();
+        JCUser cached = CACHED_USER.get();
         if (cached == null || cached.getId() != principalId){
             cached = JCUser.copyUser(userDao.loadById(principalId));
-            cachedUser.set(cached);
+            CACHED_USER.set(cached);
         }
         return cached;
     }
@@ -178,5 +178,12 @@ public class SecurityService implements UserDetailsService {
     private Object extractPrincipalFromAuthentication() {
         Authentication auth = securityContextFacade.getContext().getAuthentication();
         return auth != null ? auth.getPrincipal() : null;
+    }
+
+    /**
+     * Removes JCUser object from threadlocal storage
+     */
+    public void cleanThreadLocalStorage() {
+        CACHED_USER.remove();
     }
 }

--- a/jcommune-view/jcommune-web-controller/src/main/java/org/jtalks/jcommune/web/listeners/HttpRequestListener.java
+++ b/jcommune-view/jcommune-web-controller/src/main/java/org/jtalks/jcommune/web/listeners/HttpRequestListener.java
@@ -1,0 +1,43 @@
+/**
+ * Copyright (C) 2011  JTalks.org Team
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+package org.jtalks.jcommune.web.listeners;
+
+import org.jtalks.jcommune.service.security.SecurityService;
+
+import javax.servlet.ServletRequestEvent;
+import javax.servlet.ServletRequestListener;
+
+import static org.jtalks.jcommune.web.util.AppContextUtils.getBeanFormApplicationContext;
+
+/**
+ * Since SecurityService contain thread-local storage for JCUser objects and we are using
+ * Tomcat's thread pool some threads may contain thread-local variables and Tomcat can't
+ * clean them after application stop. So we should clean thread-local storage after each Http request.
+ *
+ * @author Oleg Tkachenko
+ */
+public class HttpRequestListener implements ServletRequestListener {
+    @Override
+    public void requestDestroyed(ServletRequestEvent sre) {
+        SecurityService securityService = getBeanFormApplicationContext(sre.getServletContext(), SecurityService.class);
+        securityService.cleanThreadLocalStorage();
+    }
+
+    @Override
+    public void requestInitialized(ServletRequestEvent sre) {
+        // DO NOTHING
+    }
+}

--- a/jcommune-view/jcommune-web-controller/src/main/java/org/jtalks/jcommune/web/listeners/SessionSetupListener.java
+++ b/jcommune-view/jcommune-web-controller/src/main/java/org/jtalks/jcommune/web/listeners/SessionSetupListener.java
@@ -22,14 +22,14 @@ import org.slf4j.LoggerFactory;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContext;
 import org.springframework.security.web.context.HttpSessionSecurityContextRepository;
-import org.springframework.web.context.WebApplicationContext;
-import org.springframework.web.context.support.WebApplicationContextUtils;
 
 import javax.servlet.ServletContext;
 import javax.servlet.http.HttpSession;
 import javax.servlet.http.HttpSessionEvent;
 import javax.servlet.http.HttpSessionListener;
 import java.util.concurrent.TimeUnit;
+
+import static org.jtalks.jcommune.web.util.AppContextUtils.getBeanFormApplicationContext;
 
 /**
  * Performs initial session setup.
@@ -57,7 +57,7 @@ public class SessionSetupListener implements HttpSessionListener {
                     if (sessionTimeoutProperty == null){
                         ServletContext context = se.getSession().getServletContext();
                         sessionTimeoutProperty = getBeanFormApplicationContext(context, JCommuneProperty.class, "sessionTimeoutProperty");
-                        locationService = getBeanFormApplicationContext(context, LocationService.class, "locationService");
+                        locationService = getBeanFormApplicationContext(context, LocationService.class);
                         int seconds = extractValueFromProperty(sessionTimeoutProperty);
                         /* Zero property value should mean infinitive session.
                         To disable session expiration we should pass negative value here.
@@ -101,21 +101,6 @@ public class SessionSetupListener implements HttpSessionListener {
         if (securityContext == null) return null;
         Authentication authentication = ((SecurityContext) securityContext).getAuthentication();
         return authentication != null ? authentication.getPrincipal() : null;
-    }
-
-    /**
-     * Returns bean from application context.
-     *
-     * @param servletContext to find the web application context for
-     * @param tClass         interface or superclass of the actual class.
-     * @param beanName       the name of the bean to retrieve
-     * @return an instance of the bean
-     * @throws IllegalStateException if the root WebApplicationContext could not be found
-     * @throws ClassCastException    if the bean found in context is not assignable to the type of tClass
-     */
-    private static <T> T getBeanFormApplicationContext(ServletContext servletContext, Class<T> tClass, String beanName) {
-        WebApplicationContext context = WebApplicationContextUtils.getRequiredWebApplicationContext(servletContext);
-        return tClass.cast(context.getBean(beanName));
     }
 
     /**

--- a/jcommune-view/jcommune-web-controller/src/main/java/org/jtalks/jcommune/web/util/AppContextUtils.java
+++ b/jcommune-view/jcommune-web-controller/src/main/java/org/jtalks/jcommune/web/util/AppContextUtils.java
@@ -1,0 +1,48 @@
+/**
+ * Copyright (C) 2011  JTalks.org Team
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+package org.jtalks.jcommune.web.util;
+
+import org.springframework.web.context.WebApplicationContext;
+import org.springframework.web.context.support.WebApplicationContextUtils;
+
+import javax.servlet.ServletContext;
+
+/**
+ * Provides possibility to get bean from ApplicationContext
+ *
+ * @author Oleg Tkachenko
+ */
+public class AppContextUtils {
+    /**
+     * Returns bean from application context.
+     *
+     * @param servletContext to find the web application context for
+     * @param tClass         interface or superclass of the actual class.
+     * @param beanName       the name of the bean to retrieve
+     * @return an instance of the bean
+     * @throws IllegalStateException if the root WebApplicationContext could not be found
+     * @throws ClassCastException    if the bean found in context is not assignable to the type of tClass
+     */
+    public static <T> T getBeanFormApplicationContext(ServletContext servletContext, Class<T> tClass, String beanName) {
+        WebApplicationContext context = WebApplicationContextUtils.getRequiredWebApplicationContext(servletContext);
+        if (beanName == null) return context.getBean(tClass);
+        return tClass.cast(context.getBean(beanName));
+    }
+
+    public static <T> T getBeanFormApplicationContext(ServletContext servletContext, Class<T> tClass) {
+        return getBeanFormApplicationContext(servletContext , tClass, null);
+    }
+}

--- a/jcommune-view/jcommune-web-view/src/main/webapp/WEB-INF/web.xml
+++ b/jcommune-view/jcommune-web-view/src/main/webapp/WEB-INF/web.xml
@@ -172,6 +172,9 @@
     <listener>
         <listener-class>org.springframework.web.util.HttpSessionMutexListener</listener-class>
     </listener>
+    <listener>
+        <listener-class>org.jtalks.jcommune.web.listeners.HttpRequestListener</listener-class>
+    </listener>
 
     <error-page>
         <error-code>400</error-code>


### PR DESCRIPTION
Tomcat can't remove JCUser objects from thread-local variables after application stop, so let's remove them after each Http request.