### PR TITLE
get rid of direct access to dao for 'create new group' operation in integration tests level.

### DIFF
--- a/jcommune-view/jcommune-web-view/src/test/java/org/jtalks/jcommune/test/AuthenticatorTest.groovy
+++ b/jcommune-view/jcommune-web-view/src/test/java/org/jtalks/jcommune/test/AuthenticatorTest.groovy
@@ -15,7 +15,6 @@
 
 package org.jtalks.jcommune.test
 
-import org.jtalks.common.model.entity.Group
 import org.jtalks.jcommune.plugin.api.exceptions.NotFoundException
 import org.jtalks.jcommune.service.Authenticator
 import org.jtalks.jcommune.service.exceptions.UserTriesActivatingAccountAgainException
@@ -30,7 +29,6 @@ import org.springframework.transaction.annotation.Transactional
 import spock.lang.Specification
 
 import static io.qala.datagen.RandomShortApi.alphanumeric
-
 /**
  * @author Oleg Tkachenko
  */
@@ -44,7 +42,7 @@ class AuthenticatorTest extends Specification {
     @Autowired Authenticator authenticator
 
     def setup() {
-        groupsService.save(new Group(AdministrationGroup.USER.name))
+        groupsService.createPredefinedGroups()
     }
 
     def 'test success account activation'(){

--- a/jcommune-view/jcommune-web-view/src/test/java/org/jtalks/jcommune/test/CreateBranchTest.groovy
+++ b/jcommune-view/jcommune-web-view/src/test/java/org/jtalks/jcommune/test/CreateBranchTest.groovy
@@ -49,7 +49,7 @@ class CreateBranchTest extends Specification {
     private Component forum
 
     def setup() {
-        groupsService.create()
+        groupsService.createPredefinedGroups()
         forum = componentService.createForumComponent()
     }
 

--- a/jcommune-view/jcommune-web-view/src/test/java/org/jtalks/jcommune/test/LocationServiceTest.groovy
+++ b/jcommune-view/jcommune-web-view/src/test/java/org/jtalks/jcommune/test/LocationServiceTest.groovy
@@ -15,12 +15,10 @@
 
 package org.jtalks.jcommune.test
 
-import org.jtalks.common.model.entity.Group
 import org.jtalks.common.model.permissions.BranchPermission
 import org.jtalks.common.service.security.SecurityContextFacade
 import org.jtalks.jcommune.model.entity.AnonymousGroup
 import org.jtalks.jcommune.service.nontransactional.LocationService
-import org.jtalks.jcommune.service.security.AdministrationGroup
 import org.jtalks.jcommune.service.security.PermissionManager
 import org.jtalks.jcommune.test.model.User
 import org.jtalks.jcommune.test.service.ComponentService
@@ -60,8 +58,7 @@ class LocationServiceTest extends Specification {
     @Autowired private SessionAuthenticationStrategy authenticationStrategy
 
     def setup() {
-        groupsService.save(new Group(AdministrationGroup.USER.name))
-        groupsService.save(new Group(AnonymousGroup.ANONYMOUS_GROUP.name))
+        groupsService.createPredefinedGroups()
     }
 
     def 'user should be in a viewers list'() {

--- a/jcommune-view/jcommune-web-view/src/test/java/org/jtalks/jcommune/test/ReadPostsControllerTest.groovy
+++ b/jcommune-view/jcommune-web-view/src/test/java/org/jtalks/jcommune/test/ReadPostsControllerTest.groovy
@@ -42,7 +42,7 @@ class ReadPostsControllerTest extends Specification {
     @Autowired Branches branches;
 
     def setup() {
-        groupsService.create()
+        groupsService.createPredefinedGroups()
     }
 
     def 'must mark topic as read'() {

--- a/jcommune-view/jcommune-web-view/src/test/java/org/jtalks/jcommune/test/SignInTest.groovy
+++ b/jcommune-view/jcommune-web-view/src/test/java/org/jtalks/jcommune/test/SignInTest.groovy
@@ -45,7 +45,7 @@ abstract class SignInTest extends Specification {
     List<Filter> filters
 
     def setup() {
-        groups.create()
+        groups.createPredefinedGroups()
     }
 
     def 'Sign in without activation registration should fail'() {

--- a/jcommune-view/jcommune-web-view/src/test/java/org/jtalks/jcommune/test/SignUpTest.groovy
+++ b/jcommune-view/jcommune-web-view/src/test/java/org/jtalks/jcommune/test/SignUpTest.groovy
@@ -47,7 +47,7 @@ abstract class SignUpTest extends Specification {
 
     def setup() {
         initNonDefaultFailParameters()
-        groups.create();
+        groups.createPredefinedGroups();
     }
 
     def 'test sign up success'() {

--- a/jcommune-view/jcommune-web-view/src/test/java/org/jtalks/jcommune/test/SpamProtectionRestApiTest.groovy
+++ b/jcommune-view/jcommune-web-view/src/test/java/org/jtalks/jcommune/test/SpamProtectionRestApiTest.groovy
@@ -42,7 +42,7 @@ class SpamProtectionRestApiTest extends Specification{
     private Component forumComponent
 
     def setup() {
-        groupsService.create()
+        groupsService.createPredefinedGroups()
         forumComponent = componentService.createForumComponent()
     }
 

--- a/jcommune-view/jcommune-web-view/src/test/java/org/jtalks/jcommune/test/TopicControllerTest.groovy
+++ b/jcommune-view/jcommune-web-view/src/test/java/org/jtalks/jcommune/test/TopicControllerTest.groovy
@@ -64,7 +64,7 @@ class TopicControllerTest extends Specification {
     List<Filter> filters;
 
     def setup() {
-        groups.create()
+        groups.createPredefinedGroups()
     }
 
     def 'test create topic'() {

--- a/jcommune-view/jcommune-web-view/src/test/java/org/jtalks/jcommune/test/TopicSearchControllerTest.groovy
+++ b/jcommune-view/jcommune-web-view/src/test/java/org/jtalks/jcommune/test/TopicSearchControllerTest.groovy
@@ -49,7 +49,7 @@ class TopicSearchControllerTest extends Specification {
     @Autowired GroupsService groupsService;
 
     def setup() {
-        groupsService.create();
+        groupsService.createPredefinedGroups();
     }
 
     def 'must not be able to send GET request to indexing data from database'() {

--- a/jcommune-view/jcommune-web-view/src/test/java/org/jtalks/jcommune/test/UserControllerTest.groovy
+++ b/jcommune-view/jcommune-web-view/src/test/java/org/jtalks/jcommune/test/UserControllerTest.groovy
@@ -41,7 +41,7 @@ class UserControllerTest extends Specification {
     @Autowired GroupsService groupsService
 
     def setup() {
-        groupsService.create()
+        groupsService.createPredefinedGroups()
     }
 
     def 'must return all the groups of a user'() {

--- a/jcommune-view/jcommune-web-view/src/test/java/org/jtalks/jcommune/test/service/GroupsService.java
+++ b/jcommune-view/jcommune-web-view/src/test/java/org/jtalks/jcommune/test/service/GroupsService.java
@@ -37,7 +37,7 @@ public class GroupsService {
 
     private @Autowired GroupDao groupDao;
 
-    public void create() {
+    public void createPredefinedGroups() {
         for (String predefinedGroupName : PREDEFINED_GROUP_NAMES) {
             createIfNotExist(predefinedGroupName);
         }
@@ -59,12 +59,7 @@ public class GroupsService {
         return groupDao.getGroupByName(groupName);
     }
 
-    public Long save(Group group){
-        groupDao.saveOrUpdate(group);
-        return getIdByName(group.getName());
-    }
-
-    public void createIfNotExist(String name){
+    private void createIfNotExist(String name){
         List<Group> groups = groupDao.getByName(name);
         if (groups.isEmpty()) groupDao.saveOrUpdate(new Group(name));
     }

--- a/jcommune-view/jcommune-web-view/src/test/java/org/jtalks/jcommune/test/utils/Groups.groovy
+++ b/jcommune-view/jcommune-web-view/src/test/java/org/jtalks/jcommune/test/utils/Groups.groovy
@@ -58,7 +58,7 @@ class Groups {
         assertView(result, "groupAdministration")
     }
 
-    void create(GroupDto group, HttpSession session) {
+    long create(GroupDto group, HttpSession session) {
         def result = mockMvc.perform(post("/group")
                 .contentType(MediaType.APPLICATION_JSON)
                 .session(session as MockHttpSession)
@@ -66,6 +66,7 @@ class Groups {
                 .andReturn()
         isAccessGranted(result)
         assertJsonResponseResult(result)
+        groupDao.getByName(group.name).get(0).id
     }
 
     void edit(GroupDto group, HttpSession session) {


### PR DESCRIPTION
get rid of direct access to dao for 'create new group' operation in integration tests level.