### PR TITLE
JC-2401

### DIFF
--- a/jcommune-service/src/main/java/org/jtalks/jcommune/service/bb2htmlprocessors/BBForeignLinksPostprocessor.java
+++ b/jcommune-service/src/main/java/org/jtalks/jcommune/service/bb2htmlprocessors/BBForeignLinksPostprocessor.java
@@ -40,19 +40,18 @@ public class BBForeignLinksPostprocessor implements TextPostProcessor {
     private static final String URL_PATTERN = "(<a .*?href=(\"|').*?(\"|')|<img .*?src=(\"|').*?(\"|'))";
 
     /**
-     * Process incoming text with adding prefix "/out" to foreign links. This prefix
-     * will be excluded from indexing by search engines (robots.txt)
+     * Process incoming text with adding attribute rel="nofollow" to foreign links.
      *
      * @return resultant text
      */
     @Override
     public String postProcess(String bbDecodedText) {
         HttpServletRequest httpServletRequest = getServletRequest();
-        return addPrefixToForeignLinks(bbDecodedText, httpServletRequest.getServerName());
+        return addRelNoFollowToForeignLinks(bbDecodedText, httpServletRequest.getServerName());
     }
 
 
-    private String addPrefixToForeignLinks(String decodedText, String serverName) {
+    private String addRelNoFollowToForeignLinks(String decodedText, String serverName) {
         Pattern linkPattern = Pattern.compile(URL_PATTERN, Pattern.DOTALL);
         Matcher linkMatcher = linkPattern.matcher(decodedText);
         String href;
@@ -63,7 +62,7 @@ public class BBForeignLinksPostprocessor implements TextPostProcessor {
             if (!href.contains(serverName) && href.split("(http|ftp|https)://", 2).length == 2
                     && href.startsWith("<a")) {
                 decodedText = decodedText.replace(href,
-                        encoded.replaceFirst("<a.*href=\"", "<a rel=\"nofollow\" href=\"" + getHrefPrefix()));
+                        encoded.replaceFirst("<a.*href=\"", "<a rel=\"nofollow\" href=\""));
             } else if(href.startsWith("<a")){
                 decodedText = decodedText.replace(href,
                         encoded.replaceFirst("<a.*href=\"", "<a href=\""));
@@ -85,16 +84,6 @@ public class BBForeignLinksPostprocessor implements TextPostProcessor {
     protected HttpServletRequest getServletRequest() {
         RequestAttributes attributes = RequestContextHolder.currentRequestAttributes();
         return ((ServletRequestAttributes) attributes).getRequest();
-    }
-
-    /**
-     * Gets prefix to add href
-     *
-     * @return prefix
-     */
-    @VisibleForTesting
-    protected String getHrefPrefix() {
-        return "/out?url=";
     }
 
 }

--- a/jcommune-service/src/test/java/org/jtalks/jcommune/service/bb2htmlprocessors/BBForeignLinksPostprocessorTest.java
+++ b/jcommune-service/src/test/java/org/jtalks/jcommune/service/bb2htmlprocessors/BBForeignLinksPostprocessorTest.java
@@ -29,22 +29,15 @@ public class BBForeignLinksPostprocessorTest {
     private BBForeignLinksPostprocessor service;
     @Mock
     private HttpServletRequest request;
-    private String prefix = "/out?url=";
     private String relAttr = "rel=\"nofollow\"";
     private String serverName = "server_name";
 
     @BeforeMethod
     public void setUp() {
         service = spy(new BBForeignLinksPostprocessor());
-        when(service.getHrefPrefix()).thenReturn(prefix);
         MockitoAnnotations.initMocks(this);
         doReturn(request).when(service).getServletRequest();
         when(request.getServerName()).thenReturn(serverName);
-    }
-
-    @Test(dataProvider = "preProcessingCommonLinks")
-    public void postprocessorShouldCorrectlyAddPrefix(String incomingText, String outcomingText) {
-        assertEquals(service.postProcess(incomingText), outcomingText);
     }
 
     @Test(dataProvider = "preProcessingImages")
@@ -75,13 +68,13 @@ public class BBForeignLinksPostprocessorTest {
     public Object[][] preProcessingCommonLinks() {
         return new Object[][]{  // {"incoming link (before)", "outcoming link (after)"}
                 {"<a href=\"http://javatalks.ru/common\"></a>",
-                        "<a " + relAttr + " href=\"" + prefix + "http://javatalks.ru/common\"></a>"},
+                        "<a " + relAttr + " href=\"http://javatalks.ru/common\"></a>"},
                 {"<a href=\"https://forum.javatalks.ru\"></a>",
-                        "<a " + relAttr + " href=\"" + prefix + "https://forum.javatalks.ru\"></a>"},
+                        "<a " + relAttr + " href=\"https://forum.javatalks.ru\"></a>"},
                 {"<a href=\"http://javatalks.ru/common\"></a>",
-                        "<a " + relAttr + " href=\"" + prefix + "http://javatalks.ru/common\"></a>"},
+                        "<a " + relAttr + " href=\"http://javatalks.ru/common\"></a>"},
                 {"<a href=\"http://javatalks.ru/common space\"></a>",
-                        "<a " + relAttr + " href=\"" + prefix + "http://javatalks.ru/common%20space\"></a>"}
+                        "<a " + relAttr + " href=\"http://javatalks.ru/common%20space\"></a>"}
 
         };
     }
@@ -90,13 +83,13 @@ public class BBForeignLinksPostprocessorTest {
     public Object[][] preProcessingSubDomainLinks() {
         return new Object[][]{  // {"incoming link (before)", "outcoming link (after)"}
                 {"<a href=\"http://blog.javatalks.ru\"></a>",
-                        "<a " + relAttr + " href=\"" + prefix + "http://blog.javatalks.ru\"></a>"},
+                        "<a " + relAttr + " href=\"http://blog.javatalks.ru\"></a>"},
                 {"<a href=\"http://www.blog.javatalks.ru\"></a>",
-                        "<a " + relAttr + " href=\"" + prefix + "http://www.blog.javatalks.ru\"></a>"},
+                        "<a " + relAttr + " href=\"http://www.blog.javatalks.ru\"></a>"},
                 {"<a href=\"http://com.blog.javatalks.ru\"></a>",
-                        "<a " + relAttr + " href=\"" + prefix + "http://com.blog.javatalks.ru\"></a>"},
+                        "<a " + relAttr + " href=\"http://com.blog.javatalks.ru\"></a>"},
                 {"<a href=\"http://com.blog.javatalks.ru/space space\"></a>",
-                        "<a " + relAttr + " href=\"" + prefix + "http://com.blog.javatalks.ru/space%20space\"></a>"},
+                        "<a " + relAttr + " href=\"http://com.blog.javatalks.ru/space%20space\"></a>"},
         };
     }
 

--- a/jcommune-view/jcommune-web-view/src/main/webapp/resources/javascript/app/global.js
+++ b/jcommune-view/jcommune-web-view/src/main/webapp/resources/javascript/app/global.js
@@ -147,19 +147,6 @@ $(document).ready(function () {
 
     });
 
-    //redirect to external links in the body of posts (and signature, profile contacts)
-    $(document).delegate('.post-content-td a, .content a, #contacts a, .test-signature a, .pm_message_view a, #editorBbCodeDiv a',
-        'mousedown', function (e) {
-            var tagName = $(e.target).prop("tagName").toLowerCase();
-            var link = $(e.target);
-            //prettyPhoto img link
-            if (tagName == 'img' || tagName != 'link') {
-                link = $(link).closest("a");
-            }
-
-            link.attr('href', link.attr('href').replace('/out?url=', ''));
-        });
-
     $(window).resize();
 
     // html5 placeholder emulation for old IE


### PR DESCRIPTION
- removed JS code from global.js that was used for redirect to external links.
- removed getHrefPrefix method and it's usages in addPrefixToForeignLinks method.
- removed test method postprocessorShouldCorrectlyAddPrefix.
- renamed addPrefixToForeignLinks -> addRelNoFollowToForeignLinks.
- fixed the rest test methods in BBForeignLinksPostprocessorTest.java.